### PR TITLE
Prospective student notification

### DIFF
--- a/cogs/invites.py
+++ b/cogs/invites.py
@@ -58,7 +58,7 @@ class Invites(commands.Cog):
                     await log(f'{purpose} {member} has joined in {channelName} and was given role {roleName}')
 
                     # If new member is a prospective student, automatically say hello
-                    await channel = self.bot.fetch_channel(702895094881058896)
+                    channel = self.bot.get_channel(702895094881058896)
                     print(f'CHANNEL: {channel}')
                     await channel.send(f'Hello, {member.mention}')
 


### PR DESCRIPTION
It works with a template hello message, needs to be updated later. Should it @cse-support or DM everyone individually? Should faculty be notified?