### PR TITLE
Issue 80 - Handling Out of Bound Errors for Corgme

### DIFF
--- a/Cogs/StudentCommands.py
+++ b/Cogs/StudentCommands.py
@@ -42,7 +42,7 @@ class StudentCommands(commands.Cog):
         images = ['dogs/corgis/' + path.name for path in Path('dogs').rglob('*.*')]
 
         # Generates a random number if no number is given
-        if number < 0:
+        if number < 0 or number > 99:
             number = randint(0, len(images) - 1)
         image = images[number]
 

--- a/Cogs/StudentCommands.py
+++ b/Cogs/StudentCommands.py
@@ -42,7 +42,7 @@ class StudentCommands(commands.Cog):
         images = ['dogs/corgis/' + path.name for path in Path('dogs').rglob('*.*')]
 
         # Generates a random number if no number is given
-        if number < 0 or number > 99:
+        if number < 0 or number > (len(images) - 1):
             number = randint(0, len(images) - 1)
         image = images[number]
 


### PR DESCRIPTION
# Description

I added an upper bound to the corgme command. Now, if the input number is greater than 99, a random corgi is displayed.

## Issues

Closes #80 

## Type of change

Select one or more of the following:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (describe below)

# How Has This Been Tested?

- [x] -corgme -1
- [x] -corgme 0
- [x] -corgme 99
- [x] -corgme 100
- [x] -corgme 2000

# Checklist:

- [x] All local commits have been pushed to remote
- [x] All changes on the base branch have been merged into this branch, either by rebase or merge
- [x] My code is [PEP-8](https://pep8.org/) compliant (excluding maximum line length, keep that to 100ish characters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [Google Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for all new functions/methods
- [x] I have made corresponding changes to the documentation
