### PR TITLE
Ratelimit fix

### DIFF
--- a/Classlists/CSE-EE/.~lock.cse-ee-2021-summer.csv#
+++ b/Classlists/CSE-EE/.~lock.cse-ee-2021-summer.csv#
@@ -1,1 +1,0 @@
-,rjslater,veronica.localdomain,25.06.2021 15:49,file:///home/rjslater/.config/libreoffice/4;

--- a/Classlists/CSE-EE/cse-ee-2021-summer.csv
+++ b/Classlists/CSE-EE/cse-ee-2021-summer.csv
@@ -23,5 +23,7 @@
 "EE 4620","wafer","CEG4324","Digital Integrated Circuit Design",
 "EE 6620","wafer","CEG4324","Digital Integrated Circuit Design",
 "EE 7410","palpatine","EE7410","Power Electronics I","#ee7410,0#Student Voice,2#TA Voice"
-"ACM","acm","acm","Association for Computing Machinery",
+"Career Services","career_services","Career Services",,
+"ACM","acm","ACM","Association for Computing Machinery",
+"IEEE","ieee","IEEE","Institute of Electrical and Electronics Engineers",
 "Collegiate Esports Club","esports_club","https://discord.gg/smmV38d",,

--- a/Cogs/ServerManagement.py
+++ b/Cogs/ServerManagement.py
@@ -80,6 +80,7 @@ class ServerManagement(commands.Cog):
             # If channels to make
             if type(row['create_channels']) != float:
                 channels = row['create_channels'].split(',')
+                print('creating channels:', channels)
                 # Create category and channels
                 if len(channels) > 0:
                     # Create category

--- a/Cogs/ServerManagement.py
+++ b/Cogs/ServerManagement.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 import os
 import re
@@ -75,6 +76,7 @@ class ServerManagement(commands.Cog):
                 if not role_exists:
                     permissions = discord.Permissions(read_messages=True, send_messages=True, embed_links=True, attach_files=True, read_message_history=True, add_reactions=True, connect=True, speak=True, stream=True, use_voice_activation=True, change_nickname=True, mention_everyone=False)
                     role = await ctx.guild.create_role(name=row['role/link'], permissions=permissions)
+                    await asyncio.sleep(1 / 30)  # 30 is safely under the 50 requests/second limit of the Discord API
                     role.mentionable = True
 
             # If channels to make
@@ -85,24 +87,31 @@ class ServerManagement(commands.Cog):
                 if len(channels) > 0:
                     # Create category
                     category = await ctx.guild.create_category(row['text'])
+                    await asyncio.sleep(1 / 30)  # 30 is safely under the 50 requests/second limit of the Discord API
                     await category.set_permissions(ctx.guild.default_role, read_messages=False)
+                    await asyncio.sleep(1 / 30)  # 30 is safely under the 50 requests/second limit of the Discord API
                     for role in ctx.guild.roles:
                         if role.name == row['role/link']:
                             await category.set_permissions(role, read_messages=True)
+                            await asyncio.sleep(1 / 30)  # 30 is safely under the 50 requests/second limit of the Discord API
 
                 # Create channels
                 for channel in channels:
                     # Create text channel
                     if channel.startswith('#'):
                         text_channel = await category.create_text_channel(channel)
+                        await asyncio.sleep(1 / 30)  # 30 is safely under the 50 requests/second limit of the Discord API
                         await text_channel.edit(topic=row['long_name'])
+                        await asyncio.sleep(1 / 30)  # 30 is safely under the 50 requests/second limit of the Discord API
                     # Create voice channel
                     else:
                         member_count, channel_name = channel.split('#')
                         if member_count == 0:
                             await category.create_voice_channel(channel_name)
+                            await asyncio.sleep(1 / 30)  # 30 is safely under the 50 requests/second limit of the Discord API
                         else:
                             await category.create_voice_channel(channel_name, user_limit=int(member_count))
+                            await asyncio.sleep(1 / 30)  # 30 is safely under the 50 requests/second limit of the Discord API
 
         # Build role menus
         await self.rolemenu(ctx)
@@ -146,7 +155,9 @@ class ServerManagement(commands.Cog):
         for category in destroy_categories:
             for channel in category.channels:
                 await channel.delete()
+                await asyncio.sleep(1 / 30)  # 30 is safely under the 50 requests/second limit of the Discord API
             await category.delete()
+            await asyncio.sleep(1 / 30)  # 30 is safely under the 50 requests/second limit of the Discord API
 
         # = Destroy Roles =
 
@@ -169,6 +180,7 @@ class ServerManagement(commands.Cog):
         # Destroy categories and all subchannels
         for role in destroy_roles:
             await role.delete()
+            await asyncio.sleep(1 / 30)  # 30 is safely under the 50 requests/second limit of the Discord API
 
     @commands.command()
     @commands.has_permissions(administrator=True)

--- a/bot.py
+++ b/bot.py
@@ -8,12 +8,15 @@ from discord_components import DiscordComponents
 from dotenv import load_dotenv
 
 from utils import *
+import logging
+
 
 intents = discord.Intents(messages=True, guilds=True, members=True, voice_states=True)
 bot = commands.Bot(command_prefix='-', intents=intents)
 start_time = time()
 load_dotenv()
 TOKEN = os.getenv('DISCORD_TOKEN')
+logging.basicConfig(level=logging.INFO)
 
 
 @bot.event


### PR DESCRIPTION
# Description

Added [logging](https://discordpy.readthedocs.io/en/stable/logging.html)
Added a 1/30s sleep after all repeated API calles in SeverManagement.py

## Issues

Closes #90 

## Type of change

Select one or more of the following:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (describe below)

# How Has This Been Tested?

I have not been able to test anything as the bot has not been able to run most server management commands. Estimated time to not be rate limited again: August 21 @ 8:30 PM EST

# Checklist:

- [X] All local commits have been pushed to remote
- [x] All changes on the base branch have been merged into this branch, either by rebase or merge
- [x] My code is [PEP-8](https://pep8.org/) compliant (excluding maximum line length, keep that to 100ish characters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [Google Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for all new functions/methods
- [x] I have made corresponding changes to the documentation
