### PR TITLE
Checked AdminCommands functionality with discord.py v2.0

### DIFF
--- a/Cogs/AdminCommands.py
+++ b/Cogs/AdminCommands.py
@@ -179,7 +179,7 @@ class AdminCommands(commands.Cog):
         channel = ctx.channel
       
         # gets 250 most recent messages posted less than 4 months ago
-        messages = await channel.history(limit=250, after=that_day, oldest_first=False).flatten()
+        messages = [message async for message in channel.history(limit=250, after=that_day, oldest_first=False)]
 
         for message in messages:
             if message.author.name == username_message.content and message.type is MessageType.default:


### PR DESCRIPTION
# Description

The history command has been updated to use a regular asynchronous iterator because the  `AsyncIterator` class and the associated `flatten` function have been deprecated. All commands in the AdminCommands Cog now seem ready for migration to discord.py v2.0.

## Issues

Closes # (issue)

## Type of change

Select one or more of the following:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (describe below)

# How Has This Been Tested?

- [x] Ran `history` command in Testing Server and obtained file with proper data rather than message stating `Unexpected error: Command raised an exception: AttributeError: 'async_generator' object has no attribute 'flatten'`

# Checklist:

- [x] All local commits have been pushed to remote
- [x] All changes on the base branch have been merged into this branch, either by rebase or merge
- [x] My code is [PEP-8](https://pep8.org/) compliant (excluding maximum line length, keep that to 100ish characters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [Google Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for all new functions/methods
- [x] I have made corresponding changes to the documentation
