### PR TITLE
Working on Slash Commands

### DIFF
--- a/Cogs/AdminCommands.py
+++ b/Cogs/AdminCommands.py
@@ -3,14 +3,14 @@ import sys
 from time import sleep
 import re
 
+import discord
 from discord.ext import commands
-from discord import MessageType
+from discord import MessageType, app_commands
 from utils import *
 
 
-async def setup(bot):
+async def setup(bot:commands.Bot):
     await bot.add_cog(AdminCommands(bot))
-
 
 class AdminCommands(commands.Cog):
     def __init__(self, bot):
@@ -318,3 +318,13 @@ class AdminCommands(commands.Cog):
         if await confirmation(self.bot, ctx):
             await ctx.send('Stopping...')
             exit(0)
+
+    @app_commands.command(description="Sending a message")
+    async def sendmessage_admincom(self, interaction:discord.Interaction):
+        """An example slash command
+        This command can be executed by anyone.
+        
+        Outputs:
+            Message to user confirming execution.
+        """
+        return await interaction.response.send_message("Hiiiiiiii, AdminCom")

--- a/Cogs/CogManagement.py
+++ b/Cogs/CogManagement.py
@@ -1,8 +1,8 @@
 from discord.ext import commands
 from utils import *
+from discord import app_commands
 
-
-async def setup(bot):
+async def setup(bot:commands.Bot):
     await bot.add_cog(CogManagement(bot))
 
 
@@ -64,3 +64,38 @@ class CogManagement(commands.Cog):
         if cog_name != 'CogManagement':
             await ctx.send(f'Unloading {cog_name}')
             await self.bot.unload_extension(f'Cogs.{cog_name}')
+
+    @commands.command()
+    @commands.has_permissions(administrator=True)
+    async def sync(self, ctx):
+        """Syncs all slash commands
+        Syncs application commands to the bot's tree specific to a server.
+        """
+
+        # TODO: Are we handling multiple servers?
+        # syncs global tree to server/guild
+        await self.bot.tree.sync(guild=ctx.guild)
+
+    @app_commands.command(description="Sending a message")
+    @app_commands.default_permissions(administrator=True)
+    async def sendmessage_cogmanage(self, interaction:discord.Interaction):
+        """An example slash command
+        This command can only be executed by those with admin permissions.
+        
+        Outputs:
+            Message to user confirming execution.
+        """
+
+        return await interaction.response.send_message("Hiiiiiiii, CogManage")
+
+    @app_commands.command(description="Sending a message")
+    @app_commands.default_permissions(administrator=True)
+    async def sendmessage_cogmanage2(self, interaction:discord.Interaction):
+        """An example slash command
+        This command can only be executed by those with admin permissions.
+        
+        Outputs:
+            Message to user confirming execution.
+        """
+
+        return await interaction.response.send_message("Hiiiiiiii, CogManage2")

--- a/Cogs/CogManagement.py
+++ b/Cogs/CogManagement.py
@@ -69,12 +69,17 @@ class CogManagement(commands.Cog):
     @commands.has_permissions(administrator=True)
     async def sync(self, ctx):
         """Syncs all slash commands
-        Syncs application commands to the bot's tree specific to a server.
+        Syncs application commands to the bot's global tree.
+        Copies to current server.
         """
 
-        # TODO: Are we handling multiple servers?
+        # TODO: Are we handling multiple servers? (currently "yes")
+        # TODO: This is a W.I.P
         # syncs global tree to server/guild
-        await self.bot.tree.sync(guild=ctx.guild)
+        await self.bot.tree.sync()
+        # the below needs to be run the first time a bot syncs to a server/guild
+        # no harm in running this everytime sync runs
+        self.bot.tree.copy_global_to(guild=ctx.guild)
 
     @app_commands.command(description="Sending a message")
     @app_commands.default_permissions(administrator=True)
@@ -99,3 +104,15 @@ class CogManagement(commands.Cog):
         """
 
         return await interaction.response.send_message("Hiiiiiiii, CogManage2")
+
+    @app_commands.command(description="Sending a message")
+    @app_commands.default_permissions(administrator=True)
+    async def tell_me_why(self, interaction:discord.Interaction):
+        """An example slash command
+        This command can only be executed by those with admin permissions.
+        
+        Outputs:
+            Message to user confirming execution.
+        """
+
+        return await interaction.response.send_message("AHHHHHHHHHHH")

--- a/Cogs/StudentCommands.py
+++ b/Cogs/StudentCommands.py
@@ -4,14 +4,14 @@ from os.path import exists
 from pathlib import Path
 from random import randint
 
+from discord import app_commands
 import discord
 from discord.ext import commands
 from utils import *
 
 from diceParser import parse
 
-
-async def setup(bot):
+async def setup(bot:commands.Bot):
     await bot.add_cog(StudentCommands(bot))
 
 


### PR DESCRIPTION
# Description

Made test slash commands and messed with their permissions. It may be better to specify the bot as a commands.bot as is being done in  the `setup` function of the `AdminCommands`, `CogManagement`, and `StudentCommands` Cogs. The `sync` command, although located in `CogManagement` works for all commands in all cogs. We have also determined how to specify admin permissions for slash commands. **It is important to note that in the Discord Developer Portal, `administrator`, `applications.commands`, and `bot` permissions must be enabled for a bot to use slash commands and specifically this code. If the bot is run more than two time per minute, the user may be rate limited.**

P.S.: We should also discuss with the team (specifically Matt) if we are handling multiple servers, as the `sync` command may need to incur changes. There is a TODO comment in the `sync` command.

Helpful video: https://www.youtube.com/watch?v=3LAdiJ5xKDI

## Issues

Closes # (issue)

## Type of change

Select one or more of the following:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (describe below)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. List any edge cases you tested.
If you come up with any edge cases you didn't test while writing this PR, cancel the PR and test again.

- [x] After startup, run `sync`, and slash commands should appear and function.
- [x] Afterwards, ensure that individuals without admin privileges are unable to see and use the `sendmessage_cogmanage` slash command.
- [x] Comment one slash command out, restart bot, and that slash command should disappear.

# Checklist:

- [x] All local commits have been pushed to remote
- [x] All changes on the base branch have been merged into this branch, either by rebase or merge
- [x] My code is [PEP-8](https://pep8.org/) compliant (excluding maximum line length, keep that to 100ish characters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [Google Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for all new functions/methods
- [x] I have made corresponding changes to the documentation
