### PR TITLE
Import from Utils fix

### DIFF
--- a/Cogs/AdminCommands.py
+++ b/Cogs/AdminCommands.py
@@ -5,6 +5,7 @@ import re
 
 from discord.ext import commands
 from discord import MessageType
+
 from utils.utils import *
 
 

--- a/Cogs/CogManagement.py
+++ b/Cogs/CogManagement.py
@@ -1,4 +1,5 @@
 from discord.ext import commands
+
 from utils.utils import *
 
 

--- a/Cogs/CourseManagement.py
+++ b/Cogs/CourseManagement.py
@@ -1,15 +1,14 @@
 import os
 import re
-
 import pandas as pd
+
 from discord.ext import commands
 from discord.utils import get
-from utils.utils import *
 from discord.ui import View
-from utils.rolebutton import RoleButton
-
-from utils.utils import *
 from discord import app_commands
+
+from utils.rolebutton import RoleButton
+from utils.utils import *
 
 
 async def setup(bot):

--- a/Cogs/Faq.py
+++ b/Cogs/Faq.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import pandas as pd
 
 from discord.ext import commands
-from utils import *
+from utils.utils import *
 
 async def setup(bot):
     channels_path = r"assets/FAQ/channels.txt"

--- a/Cogs/Faq.py
+++ b/Cogs/Faq.py
@@ -2,7 +2,9 @@ from pathlib import Path
 import pandas as pd
 
 from discord.ext import commands
+
 from utils.utils import *
+
 
 async def setup(bot):
     channels_path = r"assets/FAQ/channels.txt"
@@ -20,6 +22,7 @@ async def setup(bot):
         print("Channels file for faq command does not exist.")
     
     await bot.add_cog(Faq(bot, channel_names))
+
 
 class Faq(commands.Cog):
     def __init__(self, bot, channel_names):

--- a/Cogs/Gourmet.py
+++ b/Cogs/Gourmet.py
@@ -1,18 +1,15 @@
-import os
-import sys
-from time import sleep
-import re
 import random
 import copy
 
-from discord.ui import View, Button
+from discord.ui import View
 from discord.ext import commands
-from discord import MessageType
+
 from utils.utils import *
 
 
 async def setup(bot):
     await bot.add_cog(Gourmet(bot))
+    
 
 class Gourmet(commands.Cog):
     def __init__(self, bot):

--- a/Cogs/Gourmet.py
+++ b/Cogs/Gourmet.py
@@ -8,7 +8,7 @@ import copy
 from discord.ui import View, Button
 from discord.ext import commands
 from discord import MessageType
-from utils import *
+from utils.utils import *
 
 
 async def setup(bot):

--- a/Cogs/Listeners.py
+++ b/Cogs/Listeners.py
@@ -1,4 +1,5 @@
 from discord.ext import commands
+
 from utils.utils import *
 
 

--- a/Cogs/StudentCommands.py
+++ b/Cogs/StudentCommands.py
@@ -5,8 +5,8 @@ from pathlib import Path
 from random import randint
 
 from discord.ext import commands
-from utils.utils import *
 
+from utils.utils import *
 from diceParser import parse
 
 


### PR DESCRIPTION
# Description

Changed `from utils import *` to `from utils.utils import *` in the `Faq` and `Gourmet` Cogs. Need to do this so `discord` can be imported. **_The development branch is broken until this PR is approved._** Sorry, that's partially my bad.

## Issues

None

## Type of change

Select one or more of the following:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (describe below)

# How Has This Been Tested?

- [ ] Run the bot. It should not crash.

# Checklist:

- [x] All local commits have been pushed to remote
- [x] All changes on the base branch have been merged into this branch, either by rebase or merge
- [x] My code is [PEP-8](https://pep8.org/) compliant (excluding maximum line length, keep that to 100ish characters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [Google Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for all new functions/methods
- [x] I have made corresponding changes to the documentation
