### PR TITLE
Fixed an error to DestroyCourses

### DIFF
--- a/Cogs/CourseManagement.py
+++ b/Cogs/CourseManagement.py
@@ -172,7 +172,7 @@ class CourseManagement(commands.Cog):
 
         # drop cross-listed courses (and other roles if on the file)
         courses_df = courses_df.dropna(subset=['create_channels'])
-
+        
         # List of names of categories to be destroyed, as determined by saved csv
         category_names = courses_df['text'].tolist()
         categories = await self.get_category(ctx, category_names)
@@ -188,14 +188,17 @@ class CourseManagement(commands.Cog):
         else:
             message += f'NO CATEGORIES FOUND\n'
         
-        message += '__**DESTROY FOLLOWING ROLES**__\n'
+        await ctx.send(message)
+        
+        message = '__**DESTROY FOLLOWING ROLES**__\n'
         if len(destroy_roles):
             for role in destroy_roles:
-                message += f'{role.mention}\n'
+                message += f'{role.name}\n'
         else:
             message += f'NO ROLES FOUND\n'
-        
+
         await ctx.send(message)
+
         if not await confirmation(self.bot, ctx, 'destroy'):
             return
         


### PR DESCRIPTION
Removed sending the role's mention to make the message shorter
Sending the role's name now

# Description

Fixed an error that made `destroycourses` not work if the csv is too long

## Issues

Closes #163 

## Type of change

Select one or more of the following:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (describe below)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. List any edge cases you tested.
If you come up with any edge cases you didn't test while writing this PR, cancel the PR and test again.

- [x] Test A
      - Use `-buildcourses` with the fall 2021 csv in the `CSE Testing Server`
      - `-destroycourses` (should not error)

# Checklist:

- [x] All local commits have been pushed to remote
- [x] All changes on the base branch have been merged into this branch, either by rebase or merge
- [x] My code is [PEP-8](https://pep8.org/) compliant (excluding maximum line length, keep that to 100ish characters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [Google Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for all new functions/methods
- [x] I have made corresponding changes to the documentation
