### PR TITLE
Added URL functionality to the rolebuttons

### DIFF
--- a/Cogs/CourseManagement.py
+++ b/Cogs/CourseManagement.py
@@ -288,7 +288,10 @@ class CourseManagement(commands.Cog):
         # create the button
         view = View(timeout=None)
         this_button = RoleButton(button_name=button_name, role_name=role_name)
-        this_button.callback = this_button.on_click
+
+        # If there is not a url give it a callback otherwise continue
+        if not this_button.url:
+            this_button.callback = this_button.on_click
         view.add_item(this_button)
 
         # send to user

--- a/utils/rolebutton.py
+++ b/utils/rolebutton.py
@@ -1,8 +1,8 @@
+from validators import url
+
 import discord
 from discord.ui import Button
 from discord.utils import get
-
-from validators import url
 
 class RoleButton(Button):
     """Inherits from discord.ui.Button"""

--- a/utils/rolebutton.py
+++ b/utils/rolebutton.py
@@ -2,11 +2,18 @@ import discord
 from discord.ui import Button
 from discord.utils import get
 
+from validators import url
+
 class RoleButton(Button):
     """Inherits from discord.ui.Button"""
     def __init__(self, button_name="", role_name=""):
-        super().__init__(label=button_name)
-        self.role_name = role_name
+
+        #check if the role_name is a real URL, if so give the button the url and ignore role_name
+        if url(role_name):
+            super().__init__(label=button_name, url=role_name)
+        else:
+            super().__init__(label=button_name)
+            self.role_name = role_name
 
     async def on_click(self, interaction:discord.Interaction):
         """Gives role to or removes it from user when a role button is clicked


### PR DESCRIPTION
Checks to see if the role is a url
If so it allows url functionality

# Description

Gave the `createrolebutton` command URL compatibility

## Issues

Closes #170

## Type of change

Select one or more of the following:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (describe below)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. List any edge cases you tested.
If you come up with any edge cases you didn't test while writing this PR, cancel the PR and test again.

- [ ] Test A
       - run `/createrolebutton` with just a regular string in place of the `role_name` (see below)
       - `/createrolebutton test name` 
       - This should just create the role with the string name and create the button to give the role to you
       - run `/createrolebutton` with a URL in place of the `role_name` (see below)
       - `/createrolebutton https://discord.gg/smmV38d name`
       - This should create a button with URL functionality 

# Checklist:

- [x] All local commits have been pushed to remote
- [x] All changes on the base branch have been merged into this branch, either by rebase or merge
- [x] My code is [PEP-8](https://pep8.org/) compliant (excluding maximum line length, keep that to 100ish characters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [Google Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for all new functions/methods
- [x] I have made corresponding changes to the documentation
