### PR TITLE
Task Exception fix

### DIFF
--- a/Cogs/AdminCommands.py
+++ b/Cogs/AdminCommands.py
@@ -316,4 +316,4 @@ class AdminCommands(commands.Cog):
 
         if await confirmation(self.bot, ctx):
             await ctx.send('Stopping...')
-            exit(0)
+            await ctx.bot.close()


### PR DESCRIPTION
Instead of exit(0) which would throw an error
I used a built-in discord.py command to close the bot

# Description

Changed `exit(0)` to `ctx.bot.close()` to close the connection to discord.

## Issues

Closes #142 

## Type of change

Select one or more of the following:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (describe below)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. List any edge cases you tested.
If you come up with any edge cases you didn't test while writing this PR, cancel the PR and test again.

- [ ] Test A
       - run your bot
       - run `-shutdown` and `confirm` when prompted
       - look at the terminal

# Checklist:

- [X] All local commits have been pushed to remote
- [X] All changes on the base branch have been merged into this branch, either by rebase or merge
- [X] My code is [PEP-8](https://pep8.org/) compliant (excluding maximum line length, keep that to 100ish characters)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added [Google Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for all new functions/methods
- [X] I have made corresponding changes to the documentation
