### PR TITLE
Converted the `faq` command into a slash command

### DIFF
--- a/Cogs/Faq.py
+++ b/Cogs/Faq.py
@@ -2,6 +2,7 @@ from pathlib import Path
 import pandas as pd
 
 from discord.ext import commands
+from discord import app_commands
 
 from utils.utils import *
 
@@ -54,29 +55,30 @@ class Faq(commands.Cog):
                     answer = df.loc[df['keywords'] == message.content,"answers"].values[0]
                     await message.reply(question)
                     await message.reply(answer)
-    
-    @commands.command()
-    @commands.has_permissions(administrator=True)
-    async def faq(self, ctx):
+
+    @app_commands.command(description="Enable bot monitoring of a channel")
+    @app_commands.default_permissions(administrator=True)
+    async def faq(self, interaction:discord.Interaction):
         """Enables or disables bot monitoring of a channel
         Adds or removes channel in which command is run to a list
         Overwrites channels file with contents of list for persistent use
         """
+
         # If the channel is in the list remove it and return
-        if ctx.channel.name in self.channel_names:
-            self.channel_names.remove(ctx.channel.name)
-            await ctx.reply("FAQ has been disabled for this channel!")
+        if interaction.channel.name in self.channel_names:
+            self.channel_names.remove(interaction.channel.name)
+            await interaction.response.send_message("FAQ has been disabled for this channel!")
 
             # Logging
-            await log(self.bot, f'{ctx.author} has disabled FAQ for the {ctx.channel} channel')
+            await log(self.bot, f'{interaction.user} has disabled FAQ for the {interaction.channel} channel')
         
         # If the channel is not in the list add it to the end
         else:
-            await ctx.reply("FAQ has been enabled for this channel!")
-            self.channel_names.append(ctx.channel.name)
+            await interaction.response.send_message("FAQ has been enabled for this channel!")
+            self.channel_names.append(interaction.channel.name)
 
             # Logging
-            await log(self.bot, f'{ctx.author} has enabled FAQ for the {ctx.channel} channel') 
+            await log(self.bot, f'{interaction.user} has enabled FAQ for the {interaction.channel} channel') 
 
         channels_path = r"assets/FAQ/channels.txt"
         path = Path(channels_path)


### PR DESCRIPTION
# Description

The FAQ Cog has been changed to consist of solely slash commands.

## Issues

## Type of change

Select one or more of the following:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (describe below)

# How Has This Been Tested?

- [ ] run `-sync`
- [ ] run `/faq` in any channel
- [ ] check that `assets/FAQ/channels.txt` exists in the CSE-Discord-Bot repository locally and contains the channel name
- [ ] enter a message with a `?` mark in it (a keyword in the `sample-FAQ.csv` can also be used with a `?` and no spaces to get specific responses)
- [ ] check for bot response
- [ ] run `/faq` again in the same channel
- [ ] check that `assets/FAQ/channels.txt` in the CSE-Discord-Bot repository no longer contains the channel name
- [ ] enter a message with a `?` mark in it (a keyword in the `sample-FAQ.csv` can also be used with a `?` and no spaces to get specific responses)
- [ ] ensure bot does not respond

# Checklist:

- [x] All local commits have been pushed to remote
- [x] All changes on the base branch have been merged into this branch, either by rebase or merge
- [x] My code is [PEP-8](https://pep8.org/) compliant (excluding maximum line length, keep that to 100ish characters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [Google Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for all new functions/methods
- [x] I have made corresponding changes to the documentation
