### PR TITLE
Made the Gourmet Cog to only have slash commands

### DIFF
--- a/Cogs/Gourmet.py
+++ b/Cogs/Gourmet.py
@@ -3,6 +3,8 @@ import copy
 
 from discord.ui import View
 from discord.ext import commands
+from discord import app_commands
+
 
 from utils.utils import *
 
@@ -101,13 +103,12 @@ class Gourmet(commands.Cog):
             else:
                 await interaction.response.edit_message(content='**__You have run out of restaurants. You are going to arbys.__**', view=self)
 
-    @commands.command()
-    @commands.has_permissions(administrator=True)
-    async def feedme(self, ctx):
+    @app_commands.command(description="Sends a message with buttons to give you options on possible food choices")
+    async def feedme(self, interaction:discord.Interaction):
         """Sends a menu with options regarding restaurants
         Sends a view that ontains buttons with options to add or remove a restaurant
         or randomly select a vegan or non-vegan restaurant
         """
 
-        await ctx.send(view=self.GourmetMenu(cog=self))
-        await log(self.bot, f'{ctx.author} ran /feedMe in `#{ctx.channel}`')
+        await interaction.response.send_message(view=self.GourmetMenu(cog=self))
+        await log(self.bot, f'{interaction.user} ran /feedMe in `#{interaction.channel}`')


### PR DESCRIPTION
Changed feedme to a slash command
feedme retains the same functionality

# Description

I changed any commands inside the Gourmet Cog into a slash command.
The `feedme` command now is a slash command.
This command will retain all functionality that it had before it was a slash command
Only change to the command is I believe now any person that is not an admin can run this command. I have not tested this to be sure however.

## Issues

Closes no issues

## Type of change

Select one or more of the following:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (describe below)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. List any edge cases you tested.
If you come up with any edge cases you didn't test while writing this PR, cancel the PR and test again.

- Be sure before all of these tests to run a `-sync` command to sync the command to the tree
- [x] Test A
       - Run `-feedme`
       - This should do nothing. This test is just to be sure that it cannot be called that way anymore
- [x] Test B
       - Run `/feedme`
       - This should bring up the buttons to get a random restaurant
       - This should also log to `#bot-logs` a message of who ran the command and where
       - The button's functionality should be the same.

# Checklist:

- [X] All local commits have been pushed to remote
- [X] All changes on the base branch have been merged into this branch, either by rebase or merge
- [X] My code is [PEP-8](https://pep8.org/) compliant (excluding maximum line length, keep that to 100ish characters)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added [Google Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for all new functions/methods
- [X] I have made corresponding changes to the documentation
