### PR TITLE
CogManagement uses Slash Commands

### DIFF
--- a/Cogs/CogManagement.py
+++ b/Cogs/CogManagement.py
@@ -33,12 +33,12 @@ class CogManagement(commands.Cog):
 
         # If the file exists it loads the cog
         if exists(file):
-            await interaction.channel.send(f'Loading {cog_name}')
+            await interaction.response.send_message(f'Loading {cog_name}')
             await self.bot.load_extension(f'Cogs.{cog_name}')
             await interaction.channel.send(f'Cog {cog_name} has been loaded')
             await log(self.bot, f'{interaction.user} loaded the {cog_name} cog.')
         else:
-            await interaction.channel.send(f'Cog {cog_name} does not exist. Please be sure you spelled it correctly.')
+            await interaction.response.send_message(f'Cog {cog_name} does not exist. Please be sure you spelled it correctly.')
             await log(self.bot, f'{interaction.user} attempted to reload the {cog_name} cog, but failed.')
 
     @app_commands.command(description="Reload a specific cog")
@@ -61,12 +61,12 @@ class CogManagement(commands.Cog):
 
         # If the file exists it reloads the cog
         if exists(file):
-            await interaction.channel.send(f'Reloading {cog_name}')
+            await interaction.response.send_message(f'Reloading {cog_name}')
             await self.bot.reload_extension(f'Cogs.{cog_name}')
             await interaction.channel.send(f'Cog {cog_name} has been reloaded')
             await log(self.bot, f'{interaction.user} reloaded the {cog_name} cog.')
         else:
-            await interaction.channel.send(f'Cog {cog_name} does not exist. Please be sure you spelled it correctly.')
+            await interaction.response.send_message(f'Cog {cog_name} does not exist. Please be sure you spelled it correctly.')
             await log(self.bot, f'{interaction.user} attempted to reload the {cog_name} cog, but failed.')
 
     @app_commands.command(description="Unload a specific cog")
@@ -90,12 +90,12 @@ class CogManagement(commands.Cog):
         # If the file exists it unloads the cog
         if exists(file):
             if cog_name != 'CogManagement':
-                await interaction.channel.send(f'Unloading {cog_name}')
+                await interaction.response.send_message(f'Unloading {cog_name}')
                 await self.bot.unload_extension(f'Cogs.{cog_name}')
                 await interaction.channel.send(f'Cog {cog_name} has been unloaded')
                 await log(self.bot, f'{interaction.user} unloaded the {cog_name} cog.')
         else:
-            await interaction.channel.send(f'Cog {cog_name} does not exist. Please be sure you spelled it correctly.')
+            await interaction.response.send_message(f'Cog {cog_name} does not exist. Please be sure you spelled it correctly.')
             await log(self.bot, f'{interaction.user} attempted to unload the {cog_name} cog, but failed.')
 
     @commands.command()

--- a/Cogs/CogManagement.py
+++ b/Cogs/CogManagement.py
@@ -1,6 +1,7 @@
 from os.path import exists, abspath
 
 from discord.ext import commands
+from discord import app_commands
 
 from utils.utils import *
 
@@ -13,9 +14,9 @@ class CogManagement(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
-    @commands.command()
-    @commands.has_permissions(administrator=True)
-    async def load(self, ctx, cog_name):
+    @app_commands.command(description="Load a specific cog")
+    @app_commands.default_permissions(administrator=True)
+    async def load(self, interaction:discord.Interaction, cog_name:str):
         """Load a specific cog
         Take in the name of a cog from a user. Send a message confirming the action, and call load_extension
         command from Discord.ext, passing in cog_name. If the cog is ServerManagment, call load_server_managment
@@ -32,17 +33,17 @@ class CogManagement(commands.Cog):
 
         # If the file exists it loads the cog
         if exists(file):
-            await ctx.send(f'Loading {cog_name}')
+            await interaction.channel.send(f'Loading {cog_name}')
             await self.bot.load_extension(f'Cogs.{cog_name}')
-            await ctx.send(f'Cog {cog_name} has been loaded')
-            await log(self.bot, f'{ctx.author} loaded the {cog_name} cog.')
+            await interaction.channel.send(f'Cog {cog_name} has been loaded')
+            await log(self.bot, f'{interaction.user} loaded the {cog_name} cog.')
         else:
-            await ctx.send(f'Cog {cog_name} does not exist. Please be sure you spelled it correctly.')
-            await log(self.bot, f'{ctx.author} attempted to reload the {cog_name} cog, but failed.')
+            await interaction.channel.send(f'Cog {cog_name} does not exist. Please be sure you spelled it correctly.')
+            await log(self.bot, f'{interaction.user} attempted to reload the {cog_name} cog, but failed.')
 
-    @commands.command()
-    @commands.has_permissions(administrator=True)
-    async def reload(self, ctx, cog_name):
+    @app_commands.command(description="Reload a specific cog")
+    @app_commands.default_permissions(administrator=True)
+    async def reload(self, interaction:discord.Interaction, cog_name:str):
         """Reload a specific cog
         Take in the name of single cog from a user and reload it. Output a message confirming reload action
         and use reload extension method on the cog. If reloading server managment, call load_server_managment
@@ -60,17 +61,17 @@ class CogManagement(commands.Cog):
 
         # If the file exists it reloads the cog
         if exists(file):
-            await ctx.send(f'Reloading {cog_name}')
+            await interaction.channel.send(f'Reloading {cog_name}')
             await self.bot.reload_extension(f'Cogs.{cog_name}')
-            await ctx.send(f'Cog {cog_name} has been reloaded')
-            await log(self.bot, f'{ctx.author} reloaded the {cog_name} cog.')
+            await interaction.channel.send(f'Cog {cog_name} has been reloaded')
+            await log(self.bot, f'{interaction.user} reloaded the {cog_name} cog.')
         else:
-            await ctx.send(f'Cog {cog_name} does not exist. Please be sure you spelled it correctly.')
-            await log(self.bot, f'{ctx.author} attempted to reload the {cog_name} cog, but failed.')
+            await interaction.channel.send(f'Cog {cog_name} does not exist. Please be sure you spelled it correctly.')
+            await log(self.bot, f'{interaction.user} attempted to reload the {cog_name} cog, but failed.')
 
-    @commands.command()
-    @commands.has_permissions(administrator=True)
-    async def unload(self, ctx, cog_name):
+    @app_commands.command(description="Unload a specific cog")
+    @app_commands.default_permissions(administrator=True)
+    async def unload(self, interaction:discord.Interaction, cog_name:str):
         """Unload a specific cog
         Take in the name of a cog from a user. If the user is not trying to unload the CogManagment cog,
         send a message confirming the action. Call unload_extension command from Discord.ext, passing in
@@ -89,13 +90,13 @@ class CogManagement(commands.Cog):
         # If the file exists it unloads the cog
         if exists(file):
             if cog_name != 'CogManagement':
-                await ctx.send(f'Unloading {cog_name}')
+                await interaction.channel.send(f'Unloading {cog_name}')
                 await self.bot.unload_extension(f'Cogs.{cog_name}')
-                await ctx.send(f'Cog {cog_name} has been unloaded')
-                await log(self.bot, f'{ctx.author} unloaded the {cog_name} cog.')
+                await interaction.channel.send(f'Cog {cog_name} has been unloaded')
+                await log(self.bot, f'{interaction.user} unloaded the {cog_name} cog.')
         else:
-            await ctx.send(f'Cog {cog_name} does not exist. Please be sure you spelled it correctly.')
-            await log(self.bot, f'{ctx.author} attempted to unload the {cog_name} cog, but failed.')
+            await interaction.channel.send(f'Cog {cog_name} does not exist. Please be sure you spelled it correctly.')
+            await log(self.bot, f'{interaction.user} attempted to unload the {cog_name} cog, but failed.')
 
     @commands.command()
     @commands.has_permissions(administrator=True)


### PR DESCRIPTION
# Description

Changed commands load, reload, and unload in ``CogManagement`` to slash commands. Did not change the sync command.

## Issues

Does not close an issue.

## Type of change

Select one or more of the following:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (describe below)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. List any edge cases you tested.
If you come up with any edge cases you didn't test while writing this PR, cancel the PR and test again.

- [ ] Test A
      - Run ``-load AdminCommands`` , ``-unload AdminCommands``, or ``-reload AdminCommands``
      - Shouldn't work

- [ ] Test B
      - Run ``/unload AdminCommands`` (or reload or unload)
      - should unload/load/reload the cog called (``AdminCommands`` in this case)
      - Should also log to ``#bot-logs`` a message of the command being used

# Checklist:

- [x] All local commits have been pushed to remote
- [x] All changes on the base branch have been merged into this branch, either by rebase or merge
- [x] My code is [PEP-8](https://pep8.org/) compliant (excluding maximum line length, keep that to 100ish characters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [Google Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for all new functions/methods
- [x] I have made corresponding changes to the documentation
