### PR TITLE
CourseManagement to slash commands

### DIFF
--- a/Cogs/CourseManagement.py
+++ b/Cogs/CourseManagement.py
@@ -90,7 +90,7 @@ class CourseManagement(commands.Cog):
         Create all categories, channels, and roles
         """
 
-        await interaction.response.send_message("Please send CSV if you intend to use one.")
+        await interaction.response.send_message("Please send CSV if you intend to use one. If you do not intend to use one, the cached CSV will be used.")
         csv_filepath = f'role_lists/roles_{interaction.guild.id}.csv'
 
         csv = await interaction.client.wait_for('message', check=lambda message: message.author == interaction.user)

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -5,7 +5,7 @@ import discord
 from bing_image_downloader import downloader
 
 
-async def confirmation(bot, ctx, confirm_string='confirm'):
+async def confirmation(bot, interaction:discord.Interaction, confirm_string='confirm'):
     """Add a layer of security to sensitive commands by adding a confirmation step
     Send message to user informing what confirmation code is. Ensure the next message received is by the author
     of the origional command. If so, ensure said message is the proper confirmation code. If this is the case,
@@ -24,15 +24,15 @@ async def confirmation(bot, ctx, confirm_string='confirm'):
     """
 
     # Ask for confirmation
-    await ctx.send(f'Enter `{confirm_string}` to confirm action')
+    await interaction.channel.send(f'Enter `{confirm_string}` to confirm action')
 
     # Wait for confirmation
-    msg = await bot.wait_for('message', check=lambda message: message.author == ctx.author)
+    msg = await bot.wait_for('message', check=lambda message: message.author == interaction.user)
     if msg.content == confirm_string:
-        await ctx.send(f'Action confirmed, executing')
+        await interaction.channel.send(f'Action confirmed, executing')
         return True
     else:
-        await ctx.send(f'Confirmation failed, terminating execution')
+        await interaction.channel.send(f'Confirmation failed, terminating execution')
         return False
 
 


### PR DESCRIPTION
Changed all normal commands in CourseManagement to slash commands Edited confirmation inside utils/utils.py to include interaction

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context.
List any dependencies that are required for this change.

## Issues

Closes no issue

## Type of change

Select one or more of the following:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (describe below)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. List any edge cases you tested.
If you come up with any edge cases you didn't test while writing this PR, cancel the PR and test again.

- [x] Test A
       - Run `-sync`
       - Run `/destroycourses`
       - The bot should let you know when it is done
       - Check the categories that the bot has destroyed, they should no longer exist in the server
- [x] Test B
       - Run `/buildcourses` on this step you will need to tell the bot whether or not you have a csv.
       - The bot will ask if you have a csv, if not just send a message that does not have any attachments
       - The bot should let you know when it is done building
       - Check the categories that the bot has built, they should now exist in the server
- [x] Test C
       - Run `/buildrolemenu CS`
       - The prefix does not matter, I just say use CS because it is less typing
       - Check the `cs-class-selection` channel to see if the buttons have been made
- [x] Test D
       - This test is specifically for after you have built a role menu
       - Go to the respective `class-selection` channel
       - Click one of the newly created buttons.
       - This should give/take away a role. 

# Checklist:

- [X] All local commits have been pushed to remote
- [X] All changes on the base branch have been merged into this branch, either by rebase or merge
- [X] My code is [PEP-8](https://pep8.org/) compliant (excluding maximum line length, keep that to 100ish characters)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added [Google Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for all new functions/methods
- [X] I have made corresponding changes to the documentation
