### PR TITLE
Changed python3 to python in the shebang comment

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 import os
 from time import time
 


### PR DESCRIPTION
# Description

Changed python3 to python in the shebang comment
Need to do this for singularity container to work
May need to manually change it back in the AWS instance when messing with the main server's bot

## Issues

## Type of change

Select one or more of the following:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (describe below)

# How Has This Been Tested?

- [x] Singularity container alias for Discord.py should work

# Checklist:

- [x] All local commits have been pushed to remote
- [x] All changes on the base branch have been merged into this branch, either by rebase or merge
- [x] My code is [PEP-8](https://pep8.org/) compliant (excluding maximum line length, keep that to 100ish characters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [Google Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for all new functions/methods
- [x] I have made corresponding changes to the documentation
