### PR TITLE
Emoji

### DIFF
--- a/Cogs/CogManagement.py
+++ b/Cogs/CogManagement.py
@@ -105,5 +105,21 @@ class CogManagement(commands.Cog):
         Copies to current server.
         """
 
-        await self.bot.tree.sync()      # syncs global tree to server/guild
+        # (((await self.bot.tree.sync())[0].options)[2]).required = False
+        await self.bot.tree.sync()      # syncs global tree to server/guilds
         self.bot.tree.copy_global_to(guild=ctx.guild)       # needs to be run the first time a bot syncs to a server
+
+    @commands.command()
+    @commands.has_permissions(administrator=True)
+    async def optional(self, ctx):
+
+        # This fetches the appropriate command based off of the command ID
+        command = await self.bot.tree.fetch_command(1004468238282920042)
+        # Command is an AppCommand
+        # Options grabs the parameters in a list
+        # Options[2] is the emoji parameter
+        # Required should turn off the requirement but it reverts back afterwards
+        # print(command.get_parameter('emoji'))
+        print(command.options[2].required)
+        command.options[2].required = False
+        print(command.options[2].required)

--- a/Cogs/CourseManagement.py
+++ b/Cogs/CourseManagement.py
@@ -301,13 +301,20 @@ class CourseManagement(commands.Cog):
         view = View(timeout=None)
         this_button = RoleButton(button_name=button_name, role_name=role_name)
         if emoji != 'None':
-            this_button.emoji = emoji
-
+                this_button.emoji = emoji
+            
         # If there is not a url give it a callback otherwise continue
         if not this_button.url:
             this_button.callback = this_button.on_click
         view.add_item(this_button)
 
-        # send to user
-        # await interaction.channel.send(view=view)
-        await interaction.response.send_message(view=view)
+        
+        # send button to user and log command ran
+        try:
+            await interaction.channel.send(view=view)
+        except:
+            await interaction.channel.send("Emoji doesn't exist, please try again.")
+            await log(self.bot, f"{interaction.user} tried creating the '{button_name}' button for role '{role_name}' role in #{interaction.channel} but failed because emoji did not exist")
+        else:
+            await log(self.bot, f"{interaction.user} created the '{role_name}' role and '{button_name}' button in #{interaction.channel}")
+        

--- a/Cogs/CourseManagement.py
+++ b/Cogs/CourseManagement.py
@@ -1,5 +1,6 @@
 import os
 import re
+from typing_extensions import Required
 import pandas as pd
 
 from discord.ext import commands
@@ -268,6 +269,7 @@ class CourseManagement(commands.Cog):
 
     @app_commands.command(description="Add a role and have a button for it")
     @app_commands.default_permissions(administrator=True)
+    # @app_commands.command.get_parameter('emoji').required(False)
     async def createrolebutton(self, interaction:discord.Interaction, role_name:str, button_name:str, emoji:str):
         """Creates role menus
         Take in user input for what button and role to create
@@ -296,28 +298,3 @@ class CourseManagement(commands.Cog):
 
         # send to user
         await interaction.channel.send(view=view)
-
-    @commands.command()
-    @commands.has_permissions(administrator=True)
-    async def test(self, ctx, emoji):
-        """Creates role menus
-        Find csv and extracts columns needed through a panda dataframe
-        Create the buttons and put them in a view
-        Send the role menu consisting of the view(s) to the proper channel
-
-        Args:
-            prefix (str): used to extract courses of a major from the csv and send their buttons to the proper channel
-        """
-
-        # check for prefix
-        # await ctx.send("do you want an emoji?")
-        # emoji = (await self.bot.wait_for('message', check=lambda message: message.author == ctx.author)).content
-        print(emoji)
-
-
-        view = View(timeout=None)
-        this_button = RoleButton(button_name="test", role_name="test", emoji=emoji)
-        this_button.callback = this_button.on_click
-        view.add_item(this_button)
-
-        await ctx.send(view=view)

--- a/Cogs/CourseManagement.py
+++ b/Cogs/CourseManagement.py
@@ -1,6 +1,5 @@
 import os
 import re
-from typing_extensions import Required
 import pandas as pd
 
 from discord.ext import commands
@@ -274,7 +273,7 @@ class CourseManagement(commands.Cog):
     @app_commands.command(description="Add a role and have a button for it")
     @app_commands.default_permissions(administrator=True)
     # @app_commands.command.get_parameter('emoji').required(False)
-    async def createrolebutton(self, interaction:discord.Interaction, role_name:str, button_name:str, emoji:str):
+    async def createrolebutton(self, interaction:discord.Interaction, role_name:str, button_name:str, emoji:str = 'None'):
         """Creates role menus
         Take in user input for what button and role to create
         Check the role given to see if it is a URL
@@ -282,11 +281,11 @@ class CourseManagement(commands.Cog):
         Create the role given (if it doesn't already exist)
         Create the button and put it in a view
         Send the role menu consisting of the view to the user
+
+        EMOJIS: Regular Discord emojis can be entered into the button_name string,
+        however emojis created by user need to be entered using the emoji parameter,
+        and is added to the beginning of the button
         """
-
-        command = await self.bot.tree.fetch_command(1004468238282920042)
-        print(command.options[2].required)
-
 
         permissions = discord.Permissions(read_messages=True, send_messages=True, embed_links=True, 
                 attach_files=True, read_message_history=True, add_reactions=True, connect=True, speak=True, 
@@ -301,7 +300,7 @@ class CourseManagement(commands.Cog):
         # create the button
         view = View(timeout=None)
         this_button = RoleButton(button_name=button_name, role_name=role_name)
-        if emoji[0] == '<':
+        if emoji != 'None':
             this_button.emoji = emoji
 
         # If there is not a url give it a callback otherwise continue
@@ -310,4 +309,5 @@ class CourseManagement(commands.Cog):
         view.add_item(this_button)
 
         # send to user
-        await interaction.channel.send(view=view)
+        # await interaction.channel.send(view=view)
+        await interaction.response.send_message(view=view)

--- a/Cogs/CourseManagement.py
+++ b/Cogs/CourseManagement.py
@@ -278,6 +278,10 @@ class CourseManagement(commands.Cog):
         Send the role menu consisting of the view to the user
         """
 
+        command = await self.bot.tree.fetch_command(1004468238282920042)
+        print(command.options[2].required)
+
+
         permissions = discord.Permissions(read_messages=True, send_messages=True, embed_links=True, 
                 attach_files=True, read_message_history=True, add_reactions=True, connect=True, speak=True, 
                 stream=True, use_voice_activation=True, change_nickname=True, mention_everyone=False)

--- a/Cogs/CourseManagement.py
+++ b/Cogs/CourseManagement.py
@@ -268,7 +268,7 @@ class CourseManagement(commands.Cog):
 
     @app_commands.command(description="Add a role and have a button for it")
     @app_commands.default_permissions(administrator=True)
-    async def createrolebutton(self, interaction:discord.Interaction, role_name:str, button_name:str):
+    async def createrolebutton(self, interaction:discord.Interaction, role_name:str, button_name:str, emoji:str):
         """Creates role menus
         Take in user input for what button and role to create
         Create the role given (if it doesn't already exist)
@@ -285,11 +285,39 @@ class CourseManagement(commands.Cog):
             role = await interaction.guild.create_role(name=role_name, permissions=permissions)
             role.mentionable = True
 
+
         # create the button
         view = View(timeout=None)
         this_button = RoleButton(button_name=button_name, role_name=role_name)
+        if emoji[0] == '<':
+            this_button.emoji = emoji
         this_button.callback = this_button.on_click
         view.add_item(this_button)
 
         # send to user
         await interaction.channel.send(view=view)
+
+    @commands.command()
+    @commands.has_permissions(administrator=True)
+    async def test(self, ctx, emoji):
+        """Creates role menus
+        Find csv and extracts columns needed through a panda dataframe
+        Create the buttons and put them in a view
+        Send the role menu consisting of the view(s) to the proper channel
+
+        Args:
+            prefix (str): used to extract courses of a major from the csv and send their buttons to the proper channel
+        """
+
+        # check for prefix
+        # await ctx.send("do you want an emoji?")
+        # emoji = (await self.bot.wait_for('message', check=lambda message: message.author == ctx.author)).content
+        print(emoji)
+
+
+        view = View(timeout=None)
+        this_button = RoleButton(button_name="test", role_name="test", emoji=emoji)
+        this_button.callback = this_button.on_click
+        view.add_item(this_button)
+
+        await ctx.send(view=view)

--- a/utils/rolebutton.py
+++ b/utils/rolebutton.py
@@ -4,9 +4,11 @@ from discord.utils import get
 
 class RoleButton(Button):
     """Inherits from discord.ui.Button"""
-    def __init__(self, button_name="", role_name=""):
+    def __init__(self, button_name="", role_name="", emoji=""):
         super().__init__(label=button_name)
         self.role_name = role_name
+        if emoji:
+            super().emoji=emoji
 
     async def on_click(self, interaction:discord.Interaction):
         """Gives role to or removes it from user when a role button is clicked


### PR DESCRIPTION
# Description

The slash command ``createrolebutton`` now has optional parameter functionality of adding a custom emoji created and added by the user into Discord. Regular emojis created by Discord itself can be added to the ``button_name`` parameter without needing to use the optional ``emoji`` parameter.

## Issues

Closes #152 

## Type of change

Select one or more of the following:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (describe below)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. List any edge cases you tested.
If you come up with any edge cases you didn't test while writing this PR, cancel the PR and test again.

- [x] Test A
     - ``/createrolebutton`` role_name: ``test`` button_name: ``:joy: test``
     This should create a button with a Discord emoji ``:joy:`` along with a role ``test``
- [x] Test B
     - ``/createrolebutton`` role_name: ``Test2`` button_name: ``test2`` emoji: ``:oldapple:``
     - This should create a button with a custom Discord emoji added to the beginning of the button name.

# Checklist:

- [x] All local commits have been pushed to remote
- [x] All changes on the base branch have been merged into this branch, either by rebase or merge
- [x] My code is [PEP-8](https://pep8.org/) compliant (excluding maximum line length, keep that to 100ish characters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [Google Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for all new functions/methods
- [x] I have made corresponding changes to the documentation
