### PR TITLE
Updated `/history` arg comment

### DIFF
--- a/Cogs/AdminCommands.py
+++ b/Cogs/AdminCommands.py
@@ -192,7 +192,7 @@ class AdminCommands(commands.Cog):
         to a file. Outputs file to discord channel if it is less that 4 MB.
 
         Args:
-            username (str): username of the desired user
+            username (str): username of the desired user (without # and 4 digits)
         Outputs:
             A file to chat including all messages from a user after a date, whether those messages are a reply,
             a link to those messages, and all reactions to those messages.


### PR DESCRIPTION
# Description

I believe the `-clearrole` issue was resolved when I converted it to a slash command. For `/history`, I made clearer what is wanted for the argument (i.e., what is meant by username).

## Issues

Closes #159 

## Type of change

Select one or more of the following:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (describe below)

Updated documentation

# How Has This Been Tested?

- [x] Ensure docstrings for `/clearrole` are correct and understandable.
- [x] Ensure docstrings for `/history` are correct and understandable.

# Checklist:

- [x] All local commits have been pushed to remote
- [x] All changes on the base branch have been merged into this branch, either by rebase or merge
- [x] My code is [PEP-8](https://pep8.org/) compliant (excluding maximum line length, keep that to 100ish characters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [Google Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for all new functions/methods
- [x] I have made corresponding changes to the documentation
