### PR TITLE
Fixed double response issue

### DIFF
--- a/Cogs/CourseManagement.py
+++ b/Cogs/CourseManagement.py
@@ -270,8 +270,8 @@ class CourseManagement(commands.Cog):
                 this_button.callback = this_button.on_click
                 view.add_item(this_button)
         if not len(view.children):
-            await interaction.channel.send('No buttons were built. Please check your prefix')
-            await interaction.followup.send("No buttons were built")
+            # await interaction.channel.send('No buttons were built. Please check your prefix')
+            await interaction.followup.send("No buttons were built. Please check your prefix")
             return
         await channel.send(view=view)
         await interaction.followup.send("Role buttons have been built")

--- a/Cogs/CourseManagement.py
+++ b/Cogs/CourseManagement.py
@@ -270,7 +270,6 @@ class CourseManagement(commands.Cog):
                 this_button.callback = this_button.on_click
                 view.add_item(this_button)
         if not len(view.children):
-            # await interaction.channel.send('No buttons were built. Please check your prefix')
             await interaction.followup.send("No buttons were built. Please check your prefix")
             return
         await channel.send(view=view)


### PR DESCRIPTION
# Description

Fixed issue #202 of the bot responding twice when a non-existent prefix was used in the command ``/buildrolemenu``.

## Issues

Closes #202 

## Type of change

Select one or more of the following:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (describe below)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. List any edge cases you tested.
If you come up with any edge cases you didn't test while writing this PR, cancel the PR and test again.

- [x] Test A
     - Do ``/buildrolemenu`` prefix: ``NO`` 
     - (or just any that do not exist)
     - Should tell with an ephemeral message that buttons were not built.

# Checklist:

- [x] All local commits have been pushed to remote
- [x] All changes on the base branch have been merged into this branch, either by rebase or merge
- [x] My code is [PEP-8](https://pep8.org/) compliant (excluding maximum line length, keep that to 100ish characters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [Google Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for all new functions/methods
- [x] I have made corresponding changes to the documentation
