### PR TITLE
Fixed error in `/clear`

### DIFF
--- a/Cogs/AdminCommands.py
+++ b/Cogs/AdminCommands.py
@@ -107,7 +107,7 @@ class AdminCommands(commands.Cog):
                 await interaction.channel.send(f'Clearing {amount} messages from this channel')
                 await log(self.bot, f'{interaction.user} cleared {amount} messages from #{interaction.channel}')
                 sleep(1)
-                await interaction.channel.purge(limit=int(float(amount)) + 2)
+                await interaction.channel.purge(limit=int(float(amount)) + 1)
                 await interaction.followup.send(f'Cleared {amount} messages from this channel')
                 return
             elif amount >= 10 and not await confirmation(self.bot, interaction):
@@ -117,7 +117,7 @@ class AdminCommands(commands.Cog):
             await log(self.bot, f'{interaction.user} cleared {amount} messages from #{interaction.channel}')
 
         sleep(1)
-        await interaction.channel.purge(limit=int(float(amount)) + 5)
+        await interaction.channel.purge(limit=int(float(amount)) + 4)
         await interaction.followup.send(f'Cleared {amount} messages from this channel')
 
 


### PR DESCRIPTION
# Description

Fixed the error in `/clear` that would delete one more message of what you asked.

## Issues

Closes #201 

## Type of change

Select one or more of the following:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (describe below)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. List any edge cases you tested.
If you come up with any edge cases you didn't test while writing this PR, cancel the PR and test again.

- [x] Test A
        - Go into any text channel
        - Create 5 messages all of different numbers
               - The numbers should be in numerical order from 1-5
               - The messages should only be that number
        - Type in `/clear 3`
        - Watch 3 messages be deleted
- [x] Test B
        - Go into any text channel
        - Create 15 messages all of different numbers
              - The numbers should be in numerical order from 1-15
              - The messages should only be that number
        - Type in `/clear 13`
        - Confirm the clear
        - Watch 13 messages be deleted

# Checklist:

- [X] All local commits have been pushed to remote
- [X] All changes on the base branch have been merged into this branch, either by rebase or merge
- [X] My code is [PEP-8](https://pep8.org/) compliant (excluding maximum line length, keep that to 100ish characters)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added [Google Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for all new functions/methods
- [X] I have made corresponding changes to the documentation
