### PR TITLE
Added checking for CogManagement

### DIFF
--- a/Cogs/CogManagement.py
+++ b/Cogs/CogManagement.py
@@ -113,6 +113,9 @@ class CogManagement(commands.Cog):
                     return
                 await interaction.channel.send(f'Cog {cog_name} has been unloaded')
                 await log(self.bot, f'{interaction.user} unloaded the {cog_name} cog.')
+            else:
+                await interaction.response.send_message(f'Cannot unload {cog_name}')
+                return
         else:
             await interaction.response.send_message(f'Cog {cog_name} does not exist. Please be sure you spelled it correctly.')
             await log(self.bot, f'{interaction.user} attempted to unload the {cog_name} cog, but failed.')

--- a/Cogs/CogManagement.py
+++ b/Cogs/CogManagement.py
@@ -13,7 +13,6 @@ async def setup(bot:commands.Bot):
 class CogManagement(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
-        # self.unloaded = False
 
     @app_commands.command(description="Load a specific cog")
     @app_commands.default_permissions(administrator=True)
@@ -29,12 +28,15 @@ class CogManagement(commands.Cog):
         Outputs:
             Message to user informing them of what cog is being loaded, and when the action is done.
         """
+
         # Finds the absolute path to the cog that will be loaded
         file = abspath('Cogs/' + cog_name + '.py')
 
         # If the file exists it loads the cog
         if exists(file):
             await interaction.response.send_message(f'Loading {cog_name}')
+
+            # Attempt the load, if already loaded tell the user and return
             try:
                 await self.bot.load_extension(f'Cogs.{cog_name}')
             except:
@@ -61,14 +63,14 @@ class CogManagement(commands.Cog):
             Message to user informing them of what cog is being restarted, and when the action is done.
         """
 
-        # if self.unloaded:
-        #     await interaction.response.send_message(f'Cog {cog_name}')
         # Finds the absolute path to the cog that will be reloaded
         file = abspath('Cogs/' + cog_name + '.py')
 
         # If the file exists it reloads the cog
         if exists(file):
             await interaction.response.send_message(f'Reloading {cog_name}')
+
+            # Attempt the reload, if unloaded tell the user and return
             try:
                 await self.bot.reload_extension(f'Cogs.{cog_name}')
             except:
@@ -102,6 +104,8 @@ class CogManagement(commands.Cog):
         if exists(file):
             if cog_name != 'CogManagement':
                 await interaction.response.send_message(f'Unloading {cog_name}')
+
+                # Attempt the unload, if already unloaded tell the user and return
                 try:
                     await self.bot.unload_extension(f'Cogs.{cog_name}')
                 except:

--- a/Cogs/CogManagement.py
+++ b/Cogs/CogManagement.py
@@ -13,6 +13,7 @@ async def setup(bot:commands.Bot):
 class CogManagement(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
+        # self.unloaded = False
 
     @app_commands.command(description="Load a specific cog")
     @app_commands.default_permissions(administrator=True)
@@ -34,7 +35,11 @@ class CogManagement(commands.Cog):
         # If the file exists it loads the cog
         if exists(file):
             await interaction.response.send_message(f'Loading {cog_name}')
-            await self.bot.load_extension(f'Cogs.{cog_name}')
+            try:
+                await self.bot.load_extension(f'Cogs.{cog_name}')
+            except:
+                await interaction.channel.send(f'Cog {cog_name} is already loaded')
+                return
             await interaction.channel.send(f'Cog {cog_name} has been loaded')
             await log(self.bot, f'{interaction.user} loaded the {cog_name} cog.')
         else:
@@ -56,13 +61,19 @@ class CogManagement(commands.Cog):
             Message to user informing them of what cog is being restarted, and when the action is done.
         """
 
+        # if self.unloaded:
+        #     await interaction.response.send_message(f'Cog {cog_name}')
         # Finds the absolute path to the cog that will be reloaded
         file = abspath('Cogs/' + cog_name + '.py')
 
         # If the file exists it reloads the cog
         if exists(file):
             await interaction.response.send_message(f'Reloading {cog_name}')
-            await self.bot.reload_extension(f'Cogs.{cog_name}')
+            try:
+                await self.bot.reload_extension(f'Cogs.{cog_name}')
+            except:
+                await interaction.channel.send(f'Cog {cog_name} is unloaded')
+                return
             await interaction.channel.send(f'Cog {cog_name} has been reloaded')
             await log(self.bot, f'{interaction.user} reloaded the {cog_name} cog.')
         else:
@@ -91,7 +102,11 @@ class CogManagement(commands.Cog):
         if exists(file):
             if cog_name != 'CogManagement':
                 await interaction.response.send_message(f'Unloading {cog_name}')
-                await self.bot.unload_extension(f'Cogs.{cog_name}')
+                try:
+                    await self.bot.unload_extension(f'Cogs.{cog_name}')
+                except:
+                    await interaction.channel.send(f'Cog {cog_name} is already unloaded')
+                    return
                 await interaction.channel.send(f'Cog {cog_name} has been unloaded')
                 await log(self.bot, f'{interaction.user} unloaded the {cog_name} cog.')
         else:


### PR DESCRIPTION
Checked for break cases that would cause strain

# Description

Earlier you could reload/unload/load cogs that were unloaded/loaded already
This PR will fix that and have more error checking to ensure no unnecessary breaking of the bot

## Type of change

Select one or more of the following:

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (describe below)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. List any edge cases you tested.
If you come up with any edge cases you didn't test while writing this PR, cancel the PR and test again.

- [x] Test A
        - Run your bot
        - Run `/load StudentCommands`
        - See the error checking message
- [x] Test B
        - Run your bot
        - Run `/reload StudentCommands`
        - Run `/load StudentCommands`
        - See the error checking message
- [x] Test C
        - Run your bot
        - Run `/unload StudentCommands`
        - Run `/unload StudentCommands`
        - See the error checking message
- [x] Test D
        - Run your bot
        - Run `/unload StudentCommands`
        - Run `/reload StudentCommands`
        - See the error checking message

# Checklist:

- [X] All local commits have been pushed to remote
- [X] All changes on the base branch have been merged into this branch, either by rebase or merge
- [X] My code is [PEP-8](https://pep8.org/) compliant (excluding maximum line length, keep that to 100ish characters)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added [Google Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for all new functions/methods
- [X] I have made corresponding changes to the documentation
