### PR TITLE
Removed the conditional check for options list length

### DIFF
--- a/Cogs/StudentCommands.py
+++ b/Cogs/StudentCommands.py
@@ -160,11 +160,6 @@ class StudentCommands(commands.Cog):
         if (option10 != 'None'):
             options.append(option10)
 
-        # Need between 2 and 10 options for a poll
-        if not (1 < len(options) <= 10):
-            await interaction.response.send_message('Enter between 2 and 10 answers')
-            return
-
         # Define reactions
         if len(options) == 2 and options[0] == 'yes' and options[1] == 'no':
             reactions = ['✅', '❌']


### PR DESCRIPTION
# Description

Removed the conditional check for options list length

The length check was no longer needed as less than 2 options or more than 10 are no longer possible

## Issues

Closes #227 

## Type of change

Select one or more of the following:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Other (describe below)
  - Removed unnecessary code

# How Has This Been Tested?

- [x] Ran `/poll` command and gave it a question and 1 option
  - Verified that at least 2 options were required to run the command
- [x] Ran `/poll` command and gave it a question and 10 options
  - Verified that you cannot add more than 10 options
  - Added text after 10 options and noted that it had no effect on the options list

# Checklist:

- [x] All local commits have been pushed to remote
- [x] All changes on the base branch have been merged into this branch, either by rebase or merge
- [x] My code is [PEP-8](https://pep8.org/) compliant (excluding maximum line length, keep that to 100ish characters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [Google Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for all new functions/methods
- [x] I have made corresponding changes to the documentation
