### PR TITLE
Added error checking for status messages > 128 characters

### DIFF
--- a/Cogs/AdminCommands.py
+++ b/Cogs/AdminCommands.py
@@ -277,6 +277,9 @@ class AdminCommands(commands.Cog):
                 await self.bot.change_presence(activity=discord.Game(status))
                 await log(self.bot, f'{interaction.user} changed the custom status to "Playing {status}"')
                 await f.write(status) # write the new status to the file
+            elif len(status) > 128:
+                await interaction.followup.send("Unable to set status, length of given status is > 128")
+                return # returns so the interaction doesn't set a followup twice
         await interaction.followup.send("Status set")
     
     


### PR DESCRIPTION
# Description

Updated the error checking on the `/status` command in the `AdminCommands` cog to check for status messages that are greater than 128 characters in length. Status messages have a max size of 128 characters, so if a status message is given that is greater than 128, it will tell the user the given message is too long and the status won't be changed.

## Issues

Closes #243 

## Type of change

Select one or more of the following:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (describe below)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. List any edge cases you tested.
If you come up with any edge cases you didn't test while writing this PR, cancel the PR and test again.

- [ ] Ran `/status` command with a message length of <= 128 characters
  - Verfied that the status was changed and the normal command operation still works
- [ ] Ran `/status` command with a message length of > 128 characters
  - Verified the status was *not* changed and an error is given to the user 

# Checklist:

- [x] All local commits have been pushed to remote
- [x] All changes on the base branch have been merged into this branch, either by rebase or merge
- [x] My code is [PEP-8](https://pep8.org/) compliant (excluding maximum line length, keep that to 100ish characters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [Google Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for all new functions/methods
- [x] I have made corresponding changes to the documentation
