### PR TITLE
Fixed `/corgme` issue by changing responses to followups

### DIFF
--- a/Cogs/StudentCommands.py
+++ b/Cogs/StudentCommands.py
@@ -36,6 +36,7 @@ class StudentCommands(commands.Cog):
         Outputs:
             image: picture being sent to chat
         """
+        await interaction.response.defer()
 
         # Check if corgis dir exists
         if not exists('dogs/corgis'):
@@ -57,7 +58,7 @@ class StudentCommands(commands.Cog):
         image = images[number]
 
         # Send image
-        await interaction.response.send_message(f'Corgi #{number}:', file=discord.File(image))
+        await interaction.followup.send(f'Corgi #{number}:', file=discord.File(image))
 
         # put in the log channel that the corgme command was run
         await log(self.bot, f'{interaction.user} ran /corgme in #{interaction.channel}')

--- a/utils/utils.py
+++ b/utils/utils.py
@@ -52,7 +52,7 @@ async def download_corgis(bot, interaction, amount):
         Who sent command and the amount of pictures downloaded.
     """
 
-    await interaction.response.send_message(f'Downloading {amount} images')
+    await interaction.followup.send(f'Downloading {amount} images')
     downloader.download('corgis',
                         limit=amount,
                         output_dir='dogs',


### PR DESCRIPTION
# Description

Fixed the issue where the bot would display an error in the terminal when running the `/corgme` command without initially having the `dogs` directory. It was using a `interaction.response.send_message()` twice (once in the intial command and another if the `dogs` directory didn't exist), which is disallowed as you can only respond to an interaction once. To remedy this, I created an initial defer then sent the other messages as 'followups' rather than 'responses' to avoid the issue.

## Issues

Closes #242 

## Type of change

Select one or more of the following:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (describe below)

# How Has This Been Tested?

- [ ] Run the `/corgme` command in the CSE Testing server
  - See the awesome corgi that was sent in response 
  - Delete the `dogs` directory in the CSE bot if it exists
- [ ] Run the `/corgme' command in the CSE Testing server
  - Wait for the corgis to be downloaded
  - Watch as an awesome corgi is displayed
- [ ] Run the `/corgme` command with a specified number in the CSE Testing server
  - See the awesome corgi that was sent 
 

# Checklist:

- [x] All local commits have been pushed to remote
- [x] All changes on the base branch have been merged into this branch, either by rebase or merge
- [x] My code is [PEP-8](https://pep8.org/) compliant (excluding maximum line length, keep that to 100ish characters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [Google Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for all new functions/methods
- [x] I have made corresponding changes to the documentation
