### PR TITLE
Created `get_moss_id()` function

### DIFF
--- a/Cogs/MOSS.py
+++ b/Cogs/MOSS.py
@@ -14,7 +14,7 @@ def get_moss_id(discord_id):
         discord_id (int): the discord id of the user
 
     Returns:
-        string: the moss id associated with the user's discord id
+        string: the moss id associated with the user's discord id or none if the user is not in the CSV
     """
 
     # Assign the CSV to a variable and create a pandas dataframe

--- a/Cogs/MOSS.py
+++ b/Cogs/MOSS.py
@@ -6,6 +6,28 @@ from utils.utils import *
 import os
 import pandas as pd
 
+def get_moss_id(discord_id):
+    """Gets a user's MossID
+    Uses a provided discord_id (from the calling command's interaction) to search the CSV for the associated MossID
+
+    Args:
+        discord_id (int): the discord id of the user
+
+    Returns:
+        string: the moss id associated with the user's discord id
+    """
+
+    # Assign the CSV to a variable and create a pandas dataframe
+    csv_filepath = "assets/moss_ids.csv"
+    moss_df = pd.read_csv(csv_filepath)
+
+    if discord_id in moss_df["discord_id"].values:
+        return moss_df.loc[moss_df["discord_id"] == discord_id]["moss_id"].values[0]
+    else:
+        # From /moss, we can check if 'none' was returned and send a message to the user
+        return None
+
+
 # adds my cog to the bot
 async def setup(bot:commands.Bot):
     await bot.add_cog(MOSS(bot))


### PR DESCRIPTION
# Description

Created `get_moss_id()` function to get a user's MossID from the csv from their DiscordID. The DiscordID is retrieved from the calling command's (`/moss`) interaction and passed to the function. It will return either the user's MossID from the csv, or `None` if their DiscordID was not found in the csv. We can add a conditional check later in `/moss` to verify what was returned and prompt the user to run `/moss_register` if the function returns `None`.

## Issues

Closes #258 

## Type of change

Select one or more of the following:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (describe below)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. List any edge cases you tested.
If you come up with any edge cases you didn't test while writing this PR, cancel the PR and test again.

> Note: I modified `/test` (future `/moss` command) to add some test cases to verify what is being returned from the function when called

- [ ] Check if correct MossID is returned
  - [ ] Create a `moss_ids.csv` in the `assets` folder (this will be fixed in #259) with the following header: `discord_id,moss_id` 
  - [ ] Make sure to run `/moss_register` to add a test MossID in the csv
  - [ ] Add a temporary call to the `get_moss_id()` in the `/test` function in and pass it `interaction.user.id` with some print statements to see MossID output
  - [ ] Run `/test`and verify the output
- [ ] Check if `None` is returned when the user is not in the csv
  - [ ] Do the same as above but make sure your DiscordID is **not** in the csv
  - [ ]  Run `/test` and verify it returned `None`

# Checklist:

- [x] All local commits have been pushed to remote
- [x] All changes on the base branch have been merged into this branch, either by rebase or merge
- [x] My code is [PEP-8](https://pep8.org/) compliant (excluding maximum line length, keep that to 100ish characters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [Google Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for all new functions/methods
- [x] I have made corresponding changes to the documentation
