### PR TITLE
Check for `moss_ids.csv` on startup

### DIFF
--- a/Cogs/MOSS.py
+++ b/Cogs/MOSS.py
@@ -8,6 +8,14 @@ import pandas as pd
 
 # adds my cog to the bot
 async def setup(bot:commands.Bot):
+    # Might want to make this a global class variable at some point(?)
+    csv_filepath = "assets/moss_ids.csv"
+
+    # If the moss_ids.csv does not exist on startup, create it
+    if not os.path.exists(csv_filepath):
+        with open(csv_filepath, 'w') as file:
+            # Add the header for the df
+            file.write("discord_id,moss_id\n")
     await bot.add_cog(MOSS(bot))
 
 # constructor method that passes in Cog commands


### PR DESCRIPTION
# Description

Added a simple conditional check in the setup function of the MOSS.py cog. It checks to see if `assets/moss_ids.csv` already exists, and if it doesn't, it creates it and its header for the dataframe.

## Issues

Closes #259 

## Type of change

Select one or more of the following:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (describe below)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. List any edge cases you tested.
If you come up with any edge cases you didn't test while writing this PR, cancel the PR and test again.

- [ ] Check for valid csv creation
  - [ ] Delete `assets/moss_ids.csv` if present.
  - [ ] Run the bot.
  - [ ] Verify the `assets/moss_ids.csv` was created after the loading of the `MOSS` cog.
  - [ ] Verify the correct header (`discord_id,moss_id`) was added to the csv.
- [ ] Check behavior if csv **is** present
  - [ ] Make sure `assets/moss_ids.csv` is present.
  - [ ] Run the bot.
  - [ ] Verify nothing happened.
- [ ] Verify all current and existing MOSS.py functionality is unaltered.

# Checklist:

- [x] All local commits have been pushed to remote
- [x] All changes on the base branch have been merged into this branch, either by rebase or merge
- [x] My code is [PEP-8](https://pep8.org/) compliant (excluding maximum line length, keep that to 100ish characters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [Google Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for all new functions/methods
- [x] I have made corresponding changes to the documentation
