### PR TITLE
Added check for if moss_id is None in `/moss`

### DIFF
--- a/Cogs/MOSS.py
+++ b/Cogs/MOSS.py
@@ -98,6 +98,9 @@ class MOSS(commands.Cog):
             MOSS URL
         """
         moss_id = get_moss_id(interaction.user.id)
+        if moss_id is None:
+            await interaction.response.send_message("You do not have a MossID associated with your account. Please register your MossID with /moss_register first")
+            return
 
         # TODO change mosspath to /tmp/<mossuser>
         mosspath = f"/tmp/{moss_id}"


### PR DESCRIPTION
# Description

Added a simple conditional check to see if the returned moss_id from the `get_moss_id()` function is None, and if it is, prompts the user to first run `/moss_register`

## Issues

Closes #267 

## Type of change

Select one or more of the following:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (describe below)

# How Has This Been Tested?

- [ ] Start your discord bot
- [ ] Run `/moss` when you're **not** in the CSV
  - [ ] Notice it prompts you to use `/moss_register` first
- [ ] Run `/moss` after you're added to the CSV
  - [ ] Notice it works as intended   

# Checklist:

- [x] All local commits have been pushed to remote
- [x] All changes on the base branch have been merged into this branch, either by rebase or merge
- [x] My code is [PEP-8](https://pep8.org/) compliant (excluding maximum line length, keep that to 100ish characters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [Google Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for all new functions/methods
- [x] I have made corresponding changes to the documentation
