### PR TITLE
Moss output decode

### DIFF
--- a/Cogs/MOSS.py
+++ b/Cogs/MOSS.py
@@ -123,12 +123,15 @@ class MOSS(commands.Cog):
 
         process = subprocess.Popen(
             moss_command, stdout = subprocess.PIPE, shell=True)
-        
+
+        await interaction.channel.send("Running MOSS...")
+
         output = process.communicate()[0]
 
-        #print(output.decode())
+        # Splits the output by newline and gets the last line, which is the moss link
+        link = output.decode().split("\n")[-2]
 
-        await interaction.followup.send(output.decode())
+        await interaction.followup.send(link)
 
 
     @app_commands.command(description="Register a new MossID")

--- a/Cogs/MOSS.py
+++ b/Cogs/MOSS.py
@@ -124,7 +124,7 @@ class MOSS(commands.Cog):
         process = subprocess.Popen(
             moss_command, stdout = subprocess.PIPE, shell=True)
 
-        await interaction.channel.send("Running MOSS...")
+        await interaction.channel.send("Running MOSS (This can sometimes take 30+ seconds)...")
 
         output = process.communicate()[0]
 

--- a/utils/WSU_mossScript.py
+++ b/utils/WSU_mossScript.py
@@ -180,19 +180,21 @@ def unzip_inner_zip_files():
         # If stored is newer than current file, skip
         if stored_user_date != "NoDate" and is_more_recent(stored_user_date, current_user_date):
             continue
-        with ZipFile(unzipped_dir+os_separator+zipped_file, 'r') as zf:
-            temp_dir = unzipped_dir+os_separator + \
-                (user_last_name)+'.dir'
-            if not os.path.exists(temp_dir):
-                os.mkdir(temp_dir)
-            else:
-                shutil.rmtree(temp_dir)
-                os.mkdir(temp_dir)
-            zf.extractall(temp_dir)
-            # update the last name to have the latest date
-            user_submissions_dates[user_last_name] = current_user_date
-
-            i += 1
+        try:
+            with ZipFile(unzipped_dir+os_separator+zipped_file, 'r') as zf:
+                temp_dir = unzipped_dir+os_separator + \
+                    (user_last_name)+'.dir'
+                if not os.path.exists(temp_dir):
+                    os.mkdir(temp_dir)
+                else:
+                    shutil.rmtree(temp_dir)
+                    os.mkdir(temp_dir)
+                zf.extractall(temp_dir)
+                # update the last name to have the latest date
+                user_submissions_dates[user_last_name] = current_user_date
+                i += 1
+        except:
+            print(f'Error unzipping {unzipped_dir+os_separator+zipped_file}')
 
 
 def find_file_extension_files(search_path):


### PR DESCRIPTION
# Description

- Added an indication that displays "Running MOSS..." while moss is running
- Split the output.decode() to only display the final link to the user after the command is run
- Wrapped some of the code within `unzip_inner_zip_files()` to catch exception and prevent the command from terminating early if one of the zip files cannot be handled correctly.

## Issues

Closes #271 

## Type of change

Select one or more of the following:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (describe below)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. List any edge cases you tested.
If you come up with any edge cases you didn't test while writing this PR, cancel the PR and test again.

- [ ] Run your bot
- [ ] Verify your discord_id + moss_id are in the `moss_ids.csv`
- [ ] Run `/moss` command
- [ ] Drag/upload some example project/practice problem zip files that were downloaded directly from pilot
- [ ] Wait for MOSS to finish running
- [ ] Notice only the link is returned

# Checklist:

- [x] All local commits have been pushed to remote
- [x] All changes on the base branch have been merged into this branch, either by rebase or merge
- [x] My code is [PEP-8](https://pep8.org/) compliant (excluding maximum line length, keep that to 100ish characters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [Google Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for all new functions/methods
- [x] I have made corresponding changes to the documentation
