### PR TITLE
Moved `get_moss_id` inside the MOSS class

### DIFF
--- a/Cogs/MOSS.py
+++ b/Cogs/MOSS.py
@@ -7,27 +7,6 @@ import os
 import subprocess
 import pandas as pd
 
-def get_moss_id(discord_id):
-    """Gets a user's MossID
-    Uses a provided discord_id (from the calling command's interaction) to search the CSV for the associated MossID
-
-    Args:
-        discord_id (int): the discord id of the user
-
-    Returns:
-        string: the moss id associated with the user's discord id or none if the user is not in the CSV
-    """
-
-    # Assign the CSV to a variable and create a pandas dataframe
-    csv_filepath = "assets/moss_ids.csv"
-    moss_df = pd.read_csv(csv_filepath)
-
-    if discord_id in moss_df["discord_id"].values:
-        return moss_df.loc[moss_df["discord_id"] == discord_id]["moss_id"].values[0]
-    else:
-        # From /moss, we can check if 'none' was returned and send a message to the user
-        return None
-
 
 # adds my cog to the bot
 async def setup(bot:commands.Bot):
@@ -41,10 +20,34 @@ async def setup(bot:commands.Bot):
             file.write("discord_id,moss_id\n")
     await bot.add_cog(MOSS(bot))
 
+
 # constructor method that passes in Cog commands
 class MOSS(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
+
+
+    def get_moss_id(discord_id):
+        """Gets a user's MossID
+        Uses a provided discord_id (from the calling command's interaction) to search the CSV for the associated MossID
+
+        Args:
+            discord_id (int): the discord id of the user
+
+        Returns:
+            string: the moss id associated with the user's discord id or none if the user is not in the CSV
+        """
+
+        # Assign the CSV to a variable and create a pandas dataframe
+        csv_filepath = "assets/moss_ids.csv"
+        moss_df = pd.read_csv(csv_filepath)
+
+        if discord_id in moss_df["discord_id"].values:
+            return moss_df.loc[moss_df["discord_id"] == discord_id]["moss_id"].values[0]
+        else:
+            # From /moss, we can check if 'none' was returned and send a message to the user
+            return None
+
 
     async def delete_all(dir_path):
         """Delete all files and directories
@@ -72,6 +75,7 @@ class MOSS(commands.Cog):
         except Exception as e:
             print(f"Could not delete {file}. Error: {e}")
 
+
     async def check_moss_folder(dir_path):
         """If a folder for the moss user does not exist, creates one at the specified path. If one already exists but
         has contents, deletes all contents.
@@ -84,7 +88,8 @@ class MOSS(commands.Cog):
         
         if len(os.listdir(dir_path)) > 0:
             await MOSS.delete_all(dir_path)
-    
+
+
     @app_commands.command(description="This will check if students are cheaters") #they ALL are
     @app_commands.default_permissions(administrator=True)
     async def moss(self, interaction:discord.Interaction):
@@ -97,7 +102,7 @@ class MOSS(commands.Cog):
         Outputs:
             MOSS URL
         """
-        moss_id = get_moss_id(interaction.user.id)
+        moss_id = MOSS.get_moss_id(interaction.user.id)
 
         # TODO change mosspath to /tmp/<mossuser>
         mosspath = f"/tmp/{moss_id}"
@@ -123,7 +128,7 @@ class MOSS(commands.Cog):
 
         process = subprocess.Popen(
             moss_command, stdout = subprocess.PIPE, shell=True)
-        
+
         output = process.communicate()[0]
 
         #print(output.decode())


### PR DESCRIPTION
# Description

Moved the `get_moss_id()` function to inside the MOSS class to promote encapsulation, and changed the function call accordingly. None of the original functionality of the bot or `get_moss_id()` function were altered.

## Issues

Closes #275 

## Type of change

Select one or more of the following:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (describe below)
  - [x] Code Improvement

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. List any edge cases you tested.
If you come up with any edge cases you didn't test while writing this PR, cancel the PR and test again.

- [ ] Ran the bot
- [ ] Added print statement to `/moss` to print the moss_id
- [ ] Ran `/moss`
- [ ] Verified the correct moss_id was still returned after the moving of the `get_moss_id()` function

# Checklist:

- [x] All local commits have been pushed to remote
- [x] All changes on the base branch have been merged into this branch, either by rebase or merge
- [x] My code is [PEP-8](https://pep8.org/) compliant (excluding maximum line length, keep that to 100ish characters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [Google Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for all new functions/methods
- [x] I have made corresponding changes to the documentation
