### PR TITLE
Moss exit issue fixed

### DIFF
--- a/Cogs/MOSS.py
+++ b/Cogs/MOSS.py
@@ -114,25 +114,27 @@ class MOSS(commands.Cog):
             # if the user takes too long, the process will timeout and this message will be returned back
             await interaction.followup.send("Took too long to upload file. Please try again.")
             return
-
-        zip_filepath = f"{mosspath}/bob.zip"
-
-        # gets first attachment
-        attachment = file.attachments[0]
-
-        # if there are more than 0 attachments, the code will continue
-        # if it's not, the bot will yell at the user
-        while not len(file.attachments) > 0 or not attachment.filename.endswith(".zip"):
-            await interaction.followup.send("Please attach a .zip file")
-            file = await interaction.client.wait_for('message', check=lambda message: message.author == interaction.user, timeout=60.0)
         
         # gives the user the ability to cancel the program if they want to
         if file.content.lower() in ["cancel", "exit", "stop"]:
             await interaction.followup.send("/moss cancelled")
             return
 
+        zip_filepath = f"{mosspath}/bob.zip"
+
+        # if there are more than 0 attachments, the code will continue
+        # if it's not, the bot will yell at the user
+        if not len(file.attachments) > 0 or not file.filename.endswith(".zip"):
+            await interaction.followup.send("Please attach a .zip file. Please rerun.")
+            try:
+                file = await interaction.client.wait_for('message', check=lambda message: message.author == interaction.user, timeout=60.0)
+            except asyncio.TimeoutError:
+                await interaction.followup.send("Took too long to upload file. Please try again.")
+                return
+            return
+
         # saves .zip file
-        await attachment.save(zip_filepath)
+        await file.attachments[0].save(zip_filepath)
 
         moss_command = f'python ./utils/WSU_mossScript.py --id {moss_id}'
 

--- a/Cogs/MOSS.py
+++ b/Cogs/MOSS.py
@@ -112,11 +112,8 @@ class MOSS(commands.Cog):
             file = await interaction.client.wait_for('message', check=lambda message: message.author == interaction.user, timeout=60.0)
         except asyncio.TimeoutError:
             # if the user takes too long, the process will timeout and this message will be returned back
-            await interaction.response.send_message("Took too long to upload file. Please try again.")
-        else:
-            # I put this here in case anything else happened
-            # don't know what would happen
-            await interaction.response.send_message("Something happened...")
+            await interaction.followup.send("Took too long to upload file. Please try again.")
+            return 
 
         zip_filepath = f"{mosspath}/bob.zip"
         # if there are more than 0 attachments, the code will continue

--- a/Cogs/MOSS.py
+++ b/Cogs/MOSS.py
@@ -99,17 +99,24 @@ class MOSS(commands.Cog):
         """
         moss_id = get_moss_id(interaction.user.id)
 
-        # TODO change mosspath to /tmp/<mossuser>
         mosspath = f"/tmp/{moss_id}"
         await MOSS.check_moss_folder(mosspath)
 
         # copied and pasted - needs fixed
         await interaction.response.send_message("Please attach a .zip file of all student code!")
 
-        # saves file to the name of the .ZIP file that is given by the user
-        file = await interaction.client.wait_for('message', check=lambda message: message.author == interaction.user)
+        try:
+            # saves file to the name of the .ZIP file that is given by the user
+            # waits for 1 minute for the file to be uploaded
+            file = await interaction.client.wait_for('message', check=lambda message: message.author == interaction.user, timeout=60.0)
+        except asyncio.TimeoutError:
+            # if the user takes too long, the process will timeout and this message will be returned back
+            await channel.send("Took too long to upload file. Please try again.")
+        else:
+            # I put this here in case anything else happened
+            # don't know what would happen
+            await channel.send("Something happened...")
 
-        # TODO change bob.zip to <datestamp>.zip
         zip_filepath = f"{mosspath}/bob.zip"
         # if there are more than 0 attachments, the code will continue
         # if it's not, the bot will yell at the user

--- a/Cogs/MOSS.py
+++ b/Cogs/MOSS.py
@@ -1,4 +1,5 @@
 # imports Discord 
+import asyncio
 from discord import app_commands
 from discord.ext import commands
 from zipfile import ZipFile 
@@ -111,11 +112,11 @@ class MOSS(commands.Cog):
             file = await interaction.client.wait_for('message', check=lambda message: message.author == interaction.user, timeout=60.0)
         except asyncio.TimeoutError:
             # if the user takes too long, the process will timeout and this message will be returned back
-            await channel.send("Took too long to upload file. Please try again.")
+            await interaction.response.send_message("Took too long to upload file. Please try again.")
         else:
             # I put this here in case anything else happened
             # don't know what would happen
-            await channel.send("Something happened...")
+            await interaction.response.send_message("Something happened...")
 
         zip_filepath = f"{mosspath}/bob.zip"
         # if there are more than 0 attachments, the code will continue

--- a/Cogs/MOSS.py
+++ b/Cogs/MOSS.py
@@ -124,13 +124,12 @@ class MOSS(commands.Cog):
 
         # if there are more than 0 attachments, the code will continue
         # if it's not, the bot will yell at the user
-        if not len(file.attachments) > 0 or not file.filename.endswith(".zip"):
-            await interaction.followup.send("Please attach a .zip file. Please rerun.")
-            try:
-                file = await interaction.client.wait_for('message', check=lambda message: message.author == interaction.user, timeout=60.0)
-            except asyncio.TimeoutError:
-                await interaction.followup.send("Took too long to upload file. Please try again.")
+        if len(file.attachments) > 0:
+            if not file.attachments[0].filename.endswith(".zip"):
+                await interaction.followup.send("Please attach a .zip file. Please rerun.")
                 return
+        else:
+            await interaction.followup.send("Please attach a populated .zip file. Please rerun.")
             return
 
         # saves .zip file

--- a/Cogs/MOSS.py
+++ b/Cogs/MOSS.py
@@ -113,16 +113,31 @@ class MOSS(commands.Cog):
         except asyncio.TimeoutError:
             # if the user takes too long, the process will timeout and this message will be returned back
             await interaction.followup.send("Took too long to upload file. Please try again.")
-            return 
+            return
+
+        # gives the user the ability to cancel the program if they want to
+        if file.content.lower() in ["cancel", "exit", "stop"]:
+            await interaction.followup.send("/moss cancelled")
+            return
 
         zip_filepath = f"{mosspath}/bob.zip"
         # if there are more than 0 attachments, the code will continue
         # if it's not, the bot will yell at the user
         while not len(file.attachments) > 0:
             await interaction.followup.send("I need a populated .zip file :|")
-            file = await interaction.client.wait_for('message', check=lambda message: message.author == interaction.user)
+            file = await interaction.client.wait_for('message', check=lambda message: message.author == interaction.user, timeout=60.0)
 
-        await file.attachments[0].save(zip_filepath)
+        # gets first attachment
+        attachment = file.attachments[0]
+        print(attachment.filename)
+
+        # checks if the attachment is a .zip file
+        if not attachment.filename.endswith('.zip'):
+            await interaction.followup.send("Please attach a .zip file. Rerun /moss")
+            return
+        
+        # saves .zip file
+        await attachment.save(zip_filepath)
 
         moss_command = f'python ./utils/WSU_mossScript.py --id {moss_id}'
 

--- a/Cogs/MOSS.py
+++ b/Cogs/MOSS.py
@@ -115,21 +115,22 @@ class MOSS(commands.Cog):
             await interaction.followup.send("Took too long to upload file. Please try again.")
             return
 
-        # gives the user the ability to cancel the program if they want to
-        if file.content.lower() in ["cancel", "exit", "stop"]:
-            await interaction.followup.send("/moss cancelled")
-            return
-
         zip_filepath = f"{mosspath}/bob.zip"
+
+        # gets first attachment
+        attachment = file.attachments[0]
+
         # if there are more than 0 attachments, the code will continue
         # if it's not, the bot will yell at the user
         while not len(file.attachments) > 0 or not attachment.filename.endswith(".zip"):
             await interaction.followup.send("Please attach a .zip file")
             file = await interaction.client.wait_for('message', check=lambda message: message.author == interaction.user, timeout=60.0)
-
-        # gets first attachment
-        attachment = file.attachments[0]
         
+        # gives the user the ability to cancel the program if they want to
+        if file.content.lower() in ["cancel", "exit", "stop"]:
+            await interaction.followup.send("/moss cancelled")
+            return
+
         # saves .zip file
         await attachment.save(zip_filepath)
 

--- a/Cogs/MOSS.py
+++ b/Cogs/MOSS.py
@@ -123,18 +123,12 @@ class MOSS(commands.Cog):
         zip_filepath = f"{mosspath}/bob.zip"
         # if there are more than 0 attachments, the code will continue
         # if it's not, the bot will yell at the user
-        while not len(file.attachments) > 0:
-            await interaction.followup.send("I need a populated .zip file :|")
+        while not len(file.attachments) > 0 or not attachment.filename.endswith(".zip"):
+            await interaction.followup.send("Please attach a .zip file")
             file = await interaction.client.wait_for('message', check=lambda message: message.author == interaction.user, timeout=60.0)
 
         # gets first attachment
         attachment = file.attachments[0]
-        print(attachment.filename)
-
-        # checks if the attachment is a .zip file
-        if not attachment.filename.endswith('.zip'):
-            await interaction.followup.send("Please attach a .zip file. Rerun /moss")
-            return
         
         # saves .zip file
         await attachment.save(zip_filepath)
@@ -145,8 +139,6 @@ class MOSS(commands.Cog):
             moss_command, stdout = subprocess.PIPE, shell=True)
         
         output = process.communicate()[0]
-
-        #print(output.decode())
 
         await interaction.followup.send(output.decode())
 


### PR DESCRIPTION
# Description

If a user does not give a file within a minute of running moss, the bot will alert the user and end the program. 

## Issues

Closes #264 #278 

## Type of change

Select one or more of the following:

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (describe below)

# How Has This Been Tested?

There's only one way to test it and it worked. I ran it in bot-commands in the testing server and waited a minute. It then sent a message and stopped running.

Edit 02/27/24:
Tested it by submitting non-zip files and it returns properly
It also ends when the user types in exit, cancel, or stop

# Checklist:

- [x] All local commits have been pushed to remote
- [x] All changes on the base branch have been merged into this branch, either by rebase or merge
- [x] My code is [PEP-8](https://pep8.org/) compliant (excluding maximum line length, keep that to 100ish characters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [Google Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for all new functions/methods
- [x] I have made corresponding changes to the documentation
