### PR TITLE
Updated `/clearrole` to better follow bot permissions

### DIFF
--- a/Cogs/AdminCommands.py
+++ b/Cogs/AdminCommands.py
@@ -152,10 +152,10 @@ class AdminCommands(commands.Cog):
             await interaction.channel.send(f"The '{role_mention}' role could not be found. The `role_mention` parameter can only take role mentions (i.e. of format `@role`).")
             await log(self.bot, f"{interaction.user} tried clearing the '{role_mention}' role in #{interaction.channel} but failed because it could not be found")
             return
-        
+
         if role >= interaction.guild.me.top_role:
-            await interaction.channel.send(f"I cannot remove the {role.mention} role from members because it is higher than my top role.")
-            await log(self.bot, f"{interaction.user} tried clearing the '{role_mention}' role in #{interaction.channel} but failed because it is higher than the bot's top role")
+            await interaction.channel.send(f"I cannot remove the {role_mention} role from members because it is equal to or higher than my top role.")
+            await log(self.bot, f"{interaction.user} tried clearing the '{role_mention}' role in #{interaction.channel} but failed because it is equal to or higher than the bot's top role")
             return
 
         cleared_members = []

--- a/Cogs/AdminCommands.py
+++ b/Cogs/AdminCommands.py
@@ -152,6 +152,11 @@ class AdminCommands(commands.Cog):
             await interaction.channel.send(f"The '{role_mention}' role could not be found. The `role_mention` parameter can only take role mentions (i.e. of format `@role`).")
             await log(self.bot, f"{interaction.user} tried clearing the '{role_mention}' role in #{interaction.channel} but failed because it could not be found")
             return
+        
+        if role >= interaction.guild.me.top_role:
+            await interaction.channel.send(f"I cannot remove the {role.mention} role from members because it is higher than my top role.")
+            await log(self.bot, f"{interaction.user} tried clearing the '{role_mention}' role in #{interaction.channel} but failed because it is higher than the bot's top role")
+            return
 
         cleared_members = []
 


### PR DESCRIPTION
# Description

Added a check when using the `/clearrole` command to verify whether the bot has the ability to remove the role. The bot's roles must be higher than the role it wants to remove, or else it won't have the proper roles to remove it.
## Issues

Closes #241

## Type of change

Select one or more of the following:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (describe below)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. List any edge cases you tested.
If you come up with any edge cases you didn't test while writing this PR, cancel the PR and test again.

- [ ] Verified removal of lower roles
  - [ ] Run the bot in the CSE Testing Server
  - [ ] Run the `/clearrole` command on a role *lower* than the bot's roles in the hierarchy
  - [ ] Verify the role was properly removed as the bot has the proper permissions to do so
- [ ] Verified non-removal of same roles
  - [ ] Run the bot in the CSE Testing Server
  - [ ] Run the `/clearrole` command on one of the roles the bot *currently* has
  - [ ] Verify the role was not removed because the bot cannot remove roles of the same level
- [ ] Verified non-removal of higher roles
  - [ ] Run the bot in the CSE Testing Server
  - [ ] Run the `/clearrole` command on a role *higher* than the bot's roles
  - [ ] Verify the role was not removed because the bot cannot remove roles of a higher level 

# Checklist:

- [x] All local commits have been pushed to remote
- [x] All changes on the base branch have been merged into this branch, either by rebase or merge
- [x] My code is [PEP-8](https://pep8.org/) compliant (excluding maximum line length, keep that to 100ish characters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [Google Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for all new functions/methods
- [x] I have made corresponding changes to the documentation
