### PR TITLE
`/announce` fix

### DIFF
--- a/Cogs/AdminCommands.py
+++ b/Cogs/AdminCommands.py
@@ -36,6 +36,12 @@ class AdminCommands(commands.Cog):
         await interaction.response.send_message("Please enter a message.")
         message = await self.bot.wait_for("message", check=lambda message: message.author == interaction.user)
 
+        # Errors if the user tries to send a message over 2,000 characters (if they have nitro)
+        if (len(message.content) > 2000):
+            await interaction.channel.send("Just because you have nitro, doesn't mean I do! The 'message' parameter can only take a message of 2000 characters or less.")
+            await log(self.bot, f"{interaction.user} tried making an announcement from #{interaction.channel} but failed because the message was too long")
+            return
+
         # logs appropriately
         await log(self.bot, f"{interaction.user} has executed the announcement command in #{interaction.channel}")
 

--- a/Cogs/AdminCommands.py
+++ b/Cogs/AdminCommands.py
@@ -32,19 +32,6 @@ class AdminCommands(commands.Cog):
             Logs that the specific user used the announcement command
         """
 
-        # Gets the message from the user
-        await interaction.response.send_message("Please enter a message.")
-        message = await self.bot.wait_for("message", check=lambda message: message.author == interaction.user)
-
-        # Errors if the user tries to send a message over 2,000 characters (if they have nitro)
-        if (len(message.content) > 2000):
-            await interaction.channel.send("Just because you have nitro, doesn't mean I do! The 'message' parameter can only take a message of 2000 characters or less.")
-            await log(self.bot, f"{interaction.user} tried making an announcement from #{interaction.channel} but failed because the message was too long")
-            return
-
-        # logs appropriately
-        await log(self.bot, f"{interaction.user} has executed the announcement command in #{interaction.channel}")
-
         # gets the channel ids from the mentions
         channel_mentions_list = channel_mentions.split()
         channels = []
@@ -54,18 +41,31 @@ class AdminCommands(commands.Cog):
             try:
                 int(channel_mention[2:-1])
             except ValueError:
-                await interaction.channel.send("The `channel_mentions` parameter can only take channel mentions (i.e. of format `#channel`).")
+                await interaction.response.send_message("The `channel_mentions` parameter can only take channel mentions (i.e. of format `#channel`).")
                 await log(self.bot, f"{interaction.user} tried making an announcement from #{interaction.channel} but failed because of invalid channel mention(s)")
                 return
 
             # ensures the channels exist
             channel = discord.utils.get(interaction.guild.text_channels, id=int(channel_mention[2:-1]))
             if (channel == None):
-                await interaction.channel.send(f"The '{channel_mention}' channel could not be found. The `channel_mentions` parameter can only take channel mentions (i.e. of format `#channel`).")
+                await interaction.response.send_message(f"The '{channel_mention}' channel could not be found. The `channel_mentions` parameter can only take channel mentions (i.e. of format `#channel`).")
                 await log(self.bot, f"{interaction.user} tried making an announcement from #{interaction.channel} but failed because of invalid channel mention(s)")
                 return
             channels.append(channel)
             channel_names.append(f"#{channel.name}")
+
+        # Gets the message from the user
+        await interaction.response.send_message("Please enter a message.")
+        message = await self.bot.wait_for("message", check=lambda message: message.author == interaction.user)
+
+        # Errors if the user tries to send a message over 2,000 characters (if they have nitro)
+        if (len(message.content) > 2000):
+            await interaction.channel.send("Just because you have nitro, doesn't mean I do! The `message` parameter can only take a message of 2000 characters or less.")
+            await log(self.bot, f"{interaction.user} tried making an announcement from #{interaction.channel} but failed because the message was too long")
+            return
+
+        # logs appropriately
+        await log(self.bot, f"{interaction.user} has executed the announcement command in #{interaction.channel}")
 
         # sends the message to the specified channels
         for channel in channels:


### PR DESCRIPTION
# Description
Added a check in the `/announce` command to check if the message the user entered is > 2000 characters. This should only affect nitro users as no one else is able to even send a message over that limit.

## Issues

Closes #235 
Closes #240 

## Type of change

Select one or more of the following:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (describe below)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. List any edge cases you tested.
If you come up with any edge cases you didn't test while writing this PR, cancel the PR and test again.

**NOTE: Must have nitro to verify first test**

- [ ] Verified messages > 2000 characters are not sent
  - [ ] Run the bot in the CSE Testing Server
  - [ ] Use `/announce` command
  - [ ] Designate a channel for the announcement to be sent to
  - [ ] Enter a message > 2000 characters
  - [ ] Notice it was not sent and an appropriate error message was displayed
- [ ] Verified messages < 2000 characters are sent
  - [ ] Run the bot in the CSE Testing Server
  - [ ] Use `/announce` command
  - [ ] Designate a channel for the announcement to be sent to
  - [ ] Enter a message < 2000 characters
  - [ ] Notice the message was sent and normal functionality is kept 
- [ ] Verified improper channel mentions are sent before asking for message
  - [ ] Run the bot in the CSE Testing Server
  - [ ] Use `/announce` command
  - [ ] Enter in an *improper* channel name
  - [ ] Verify an error was displayed and the command was terminated  

# Checklist:

- [x] All local commits have been pushed to remote
- [x] All changes on the base branch have been merged into this branch, either by rebase or merge
- [x] My code is [PEP-8](https://pep8.org/) compliant (excluding maximum line length, keep that to 100ish characters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [Google Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for all new functions/methods
- [x] I have made corresponding changes to the documentation
