### PR TITLE
Fixed #286 to log role name instead of role ID

### DIFF
--- a/Cogs/AdminCommands.py
+++ b/Cogs/AdminCommands.py
@@ -156,12 +156,12 @@ class AdminCommands(commands.Cog):
         role = discord.utils.get(guild.roles, id=int(role_mention[3:-1]))
         if role == None:
             await interaction.channel.send(f"The '{role_mention}' role could not be found. The `role_mention` parameter can only take role mentions (i.e. of format `@role`).")
-            await log(self.bot, f"{interaction.user} tried clearing the '{role_mention}' role in #{interaction.channel} but failed because it could not be found")
+            await log(self.bot, f"{interaction.user} tried clearing the '@{role.name}' role in #{interaction.channel} but failed because it could not be found")
             return
 
         if role >= interaction.guild.me.top_role:
             await interaction.channel.send(f"I cannot remove the {role_mention} role from members because it is equal to or higher than my top role.")
-            await log(self.bot, f"{interaction.user} tried clearing the '{role_mention}' role in #{interaction.channel} but failed because it is equal to or higher than the bot's top role")
+            await log(self.bot, f"{interaction.user} tried clearing the '@{role.name}' role in #{interaction.channel} but failed because it is equal to or higher than the bot's top role")
             return
 
         cleared_members = []


### PR DESCRIPTION
# Description

I changed the calls for `role_mention` in the bottom 2 conditional checks for the role to instead be `role.name` for better logs readability. I did not have to change the first one (shown in the below code) as the `role` variable is not yet defined, so it would cause errors.

```python
try:
    int(role_mention[3:-1])
except ValueError:
    await interaction.channel.send("The `role_mention` parameter can only take role mentions (i.e. of format `@role`).")
    await log(self.bot, f"{interaction.user} tried clearing the '{role_mention}' role in #{interaction.channel} but failed because of an invalid role mention")
    return
```

## Issues

Closes #286 

## Type of change

Select one or more of the following:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (describe below)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. List any edge cases you tested.
If you come up with any edge cases you didn't test while writing this PR, cancel the PR and test again.

- [ ] Run the CSE Bot in the CSE Testing Server
- [ ] Attempt to remove `@admin` role using `/clearrole` command
- [ ] See the error was logged and the `role_name` was printed instead of the `role_id`

# Checklist:

- [x] All local commits have been pushed to remote
- [x] All changes on the base branch have been merged into this branch, either by rebase or merge
- [x] My code is [PEP-8](https://pep8.org/) compliant (excluding maximum line length, keep that to 100ish characters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [Google Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for all new functions/methods
- [x] I have made corresponding changes to the documentation
