### PR TITLE
Ability to edit bot messages

### DIFF
--- a/Cogs/AdminCommands.py
+++ b/Cogs/AdminCommands.py
@@ -225,7 +225,11 @@ class AdminCommands(commands.Cog):
 
         if message == None:
             await interaction.followup.send(f"The message with the ID {message_id} could not be found. Make sure you are in same channel as the message you wish to edit.")
-            await log(self.bot, f"{interaction.user} tried to edit the message with the ID {message_id} in #{interaction.channel} but failed because the message could not be found")
+            await log(self.bot, f"{interaction.user} tried to edit the message with the ID `{message_id}` in #{interaction.channel} but failed because the message could not be found")
+            return
+        elif message.author != self.bot.user:
+            await interaction.followup.send(f"The message with the ID {message_id} is not a message sent by the bot.")
+            await log(self.bot, f"{interaction.user} tried to edit the message with the ID `{message_id}` in #{interaction.channel} but failed because it was not a message sent by the bot")
             return
 
         bot_message = await interaction.followup.send(f"Please enter the new message. Type 'cancel' to cancel.")
@@ -241,7 +245,7 @@ class AdminCommands(commands.Cog):
             else:
                 await message.edit(content=new_message.content)
                 await new_message.delete()
-                await log(self.bot, f"{interaction.user} edited the message with the ID {message_id} in #{interaction.channel}")
+                await log(self.bot, f"{interaction.user} edited the message with the ID `{message_id}` in #{interaction.channel}")
         except asyncio.TimeoutError:
             await interaction.followup.send("You took too long to respond. Exiting command...")
             return

--- a/Cogs/AdminCommands.py
+++ b/Cogs/AdminCommands.py
@@ -228,17 +228,23 @@ class AdminCommands(commands.Cog):
             await log(self.bot, f"{interaction.user} tried to edit the message with the ID {message_id} in #{interaction.channel} but failed because the message could not be found")
             return
 
-        await interaction.followup.send(f"Please enter the new message.")
+        bot_message = await interaction.followup.send(f"Please enter the new message. Type 'cancel' to cancel.")
 
         try:
             new_message = await self.bot.wait_for("message", check=lambda message: message.author == interaction.user, timeout=60.0)
+            
+            if new_message.content == 'cancel':
+                await bot_message.edit(content="Message edit cancelled")
+                await new_message.delete()
+                await log(self.bot, f"{interaction.user} cancelled the edit of the message in #{interaction.channel}")
+                return
+            else:
+                await message.edit(content=new_message.content)
+                await new_message.delete()
+                await log(self.bot, f"{interaction.user} edited the message with the ID {message_id} in #{interaction.channel}")
         except asyncio.TimeoutError:
             await interaction.followup.send("You took too long to respond. Exiting command...")
             return
-
-        await message.edit(content=new_message.content)
-
-        await log(self.bot, f"{interaction.user} edited the message with the ID {message_id} in #{interaction.channel}")
 
 
     @app_commands.command(description="outputs all messages from a specified user after a specified date with some metadata to a file")


### PR DESCRIPTION
# Description

Created a new `/edit_message` command to edit previously sent messages from the bot. The command must be run in the same channel as the desired message you wish to edit was in. 

## Issues

Closes #295 

## Type of change

Select one or more of the following:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (describe below)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. List any edge cases you tested.
If you come up with any edge cases you didn't test while writing this PR, cancel the PR and test again.

- [ ] Correctly editing a sent message
  - [ ] Run the bot in the CSE Testing Server
  - [ ] Run the `/edit_message` command with the correct `message_id`
  - [ ] Send the new content of the message
  - [ ] See the original message get edited and the user message was deleted
- [ ] Providing an invalid `message_id`
  - [ ] Run the bot in the CSE Testing Server
  - [ ] Run `/edit_message` command with an incorrect or not-found `message_id`
  - [ ] See the bot errors and a log is created in `#bot-logs`
- [ ] Trying to edit a non-bot message
  - [ ] Run the bot in the CSE Testing Server
  - [ ] Run `/edit_message` with the `message_id` of a message sent by another user
  - [ ] See the bot errors and a log is created in `#bot-logs`
- [ ] Cancel the process of editing a message
  - [ ] Run the bot in the CSE Testing Server
  - [ ] Run `/edit_message` with a correct `message_id`
  - [ ] Send 'cancel' as the message
  - [ ] See the command execution was terminated
- [ ] Timeout while editing a message
  - [ ] Run the bot in the CSE Testing Server
  - [ ] Run `/edit_message` with a correct `message_id`
  - [ ] Don't send a message and wait 60s
  - [ ] See the execution was terminated and an error message appeared

# Checklist:

- [x] All local commits have been pushed to remote
- [x] All changes on the base branch have been merged into this branch, either by rebase or merge
- [x] My code is [PEP-8](https://pep8.org/) compliant (excluding maximum line length, keep that to 100ish characters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [Google Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for all new functions/methods
- [x] I have made corresponding changes to the documentation
