### PR TITLE
`/createrolebutton` fix

### DIFF
--- a/Cogs/CourseManagement.py
+++ b/Cogs/CourseManagement.py
@@ -350,11 +350,18 @@ class CourseManagement(commands.Cog):
                 attach_files=True, read_message_history=True, add_reactions=True, connect=True, speak=True, 
                 stream=True, use_voice_activation=True, change_nickname=True, mention_everyone=False)
 
+        # if a user entered a role mention, get the role object + name
+        if role_name.startswith("<@&") and role_name.endswith(">"):
+            role_name = role_name[3:-1]
+            role = interaction.guild.get_role(int(role_name))
+
+            if role:
+                role_name = role.name
+
         # create the role if it does not exist
         if not get(interaction.guild.roles, name=role_name):
             role = await interaction.guild.create_role(name=role_name, permissions=permissions)
             role.mentionable = True
-
 
         # create the button
         view = View(timeout=None)
@@ -367,7 +374,6 @@ class CourseManagement(commands.Cog):
             this_button.callback = this_button.on_click
         view.add_item(this_button)
 
-        
         # send button to user and log command ran
         try:
             await interaction.channel.send(view=view)

--- a/Cogs/CourseManagement.py
+++ b/Cogs/CourseManagement.py
@@ -353,7 +353,11 @@ class CourseManagement(commands.Cog):
         # if a user entered a role mention, get the role object + name
         if role_name.startswith("<@&") and role_name.endswith(">"):
             role_name = role_name[3:-1]
-            role = interaction.guild.get_role(int(role_name))
+
+            try:
+                role = interaction.guild.get_role(int(role_name))
+            except ValueError:
+                role = None
 
             if role:
                 role_name = role.name


### PR DESCRIPTION
# Description

Added check to see if the given role_name string is in the format of a role mention, and if it is, get the appropriate role from the server. This allows the ability to enter a role mention to create a role button, along with the option of just the role name as well.

## Issues

Closes #293 

## Type of change

Select one or more of the following:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (describe below)

# How Has This Been Tested?

- [ ] Create role button with @ role mention
  - [ ] Run `/createrolebutton` in the testing server
  - [ ] Enter an @ role mention in the role_name parameter
  - [ ] Enter the remaining information and create the button
  - [ ] Click the button and verify the correct role is given/removed from you
- [ ] Create role button with role name
  - [ ] Run `/createrolebutton` in the testing server
  - [ ] Enter the string name of a role in the server (or not in the server, in which case it will create it)
  - [ ] Enter the remaining information and create the button
  - [ ] Click the button and verify the correct role is given/removed from you 
- [ ] Create role button with <@&> in the string (I doubt anyone would do this but I wanted to cover all bases)
  - [ ] Run `/createrolebutton` in the testing server
  - [ ] Enter the string name of a role with `<@&` leading and `>` tailing the given string
  - [ ] Enter the remaining information and create the button
  - [ ] Click the button and verify the role is given/removed from you
  
*Currently, the `<@&` and `>` are still stripped from the string even if its not a valid role, this can be updated later if needed, but I highly doubt anyone wants to create a role of that name lol*

# Checklist:

- [x] All local commits have been pushed to remote
- [x] All changes on the base branch have been merged into this branch, either by rebase or merge
- [x] My code is [PEP-8](https://pep8.org/) compliant (excluding maximum line length, keep that to 100ish characters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [Google Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for all new functions/methods
- [x] I have made corresponding changes to the documentation
