### PR TITLE
Checkin register and view

### DIFF
--- a/Cogs/Checkin.py
+++ b/Cogs/Checkin.py
@@ -18,7 +18,16 @@ class Checkin(commands.Cog):
     class CheckinView(View):
         @discord.ui.button(label="Check-in", style=discord.ButtonStyle.green)
         async def checkin(self, interaction:discord.Interaction, button:discord.ui.Button):
-            """A button that will create a timesheet for the user in the SQLite database"""
+            """A button that will create a timesheet for the user in the SQLite database
+
+            This will eventually have some database interaction
+
+            Args:
+                button (discord.ui.Button): the channels to which the announcement is sent
+
+            Outputs:
+                A View with a button that will create a timesheet for the user in the SQLite database
+            """
 
             # This will eventually have some database interaction
             await interaction.response.send_message("You have checked in! (not really)")
@@ -26,7 +35,11 @@ class Checkin(commands.Cog):
     @app_commands.command(name="checkin-register", description="Register for checkin/timesheets!")
     async def checkin_register(self, interaction:discord.Interaction):
         """Allows a user to register for a check-in
+
         This will eventually have some database interaction
+
+        Outputs:
+            A palceholder message to confirm a DM was sent to the user
         """
 
         discordID = interaction.user.id # for later use

--- a/Cogs/Checkin.py
+++ b/Cogs/Checkin.py
@@ -1,9 +1,8 @@
 import csv
 import os
 import pandas as pd
-from typing import List
-from validators import url
 
+from discord.ui import View
 from discord.ext import commands
 from discord import app_commands
 
@@ -16,151 +15,10 @@ class Checkin(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
 
-    async def add_task(self, interaction:discord.Interaction, filepath:str, channel:discord.DMChannel):
-        """A function that creates a task
-        Creates and adds a task based on user input to the tasks.csv file
+    class CheckinView(View):
+        @discord.ui.button(label="Check-in", style=discord.ButtonStyle.green)
+        async def checkin(self, interaction:discord.Interaction, button:discord.ui.Button):
+            """A button that will create a timesheet for the user in the SQLite database"""
 
-        Args:
-            filepath (str): String representation of the path to the csv file
-            channel (discord.Channel): Channel to send the discord messages to
-
-        Outputs:
-            Message to chat displaying the task name and number of the new task that was created
-        """
-
-        await channel.send("Enter the name of the task you wish to create")
-        task_name = await self.bot.wait_for('message', check=lambda message: message.author == interaction.user)
-
-        await channel.send("Enter the link to a Github issue if applicable.\nEnter `none` if there is no issue.")
-        issue_link = await self.bot.wait_for('message', check=lambda message: message.author == interaction.user)
-
-        tasks_df = pd.read_csv(filepath)
-        task_numbers = tasks_df["number"].to_list()
-
-        task_num = 1
-        if (len(task_numbers) != 0):
-            task_num = task_numbers[-1] + 1
-        
-        if (issue_link.content.casefold() == "none" or not url(issue_link.content)):
-            task_as_list = [interaction.user.id, task_name.content, task_num, '', "Incomplete", 0]
-            await channel.send("No valid link was entered, task is still being created...")
-        else:
-            task_as_list = [interaction.user.id, task_name.content, task_num, issue_link.content, "Incomplete", 0]
-
-        csv_file = open(filepath, 'a')
-        writer = csv.writer(csv_file)
-        writer.writerow(task_as_list)
-        csv_file.close()
-
-        await channel.send(f'Task "{task_name.content}" with ID "{task_num}" has been created.')
-
-    async def list_tasks(self, interaction:discord.Interaction, filepath:str, channel:discord.DMChannel):
-        """A function that lists all tasks
-        Lists the tasks that are currently in the tasks.csv
-
-        Args:
-            filepath (str): String representation of the path to the csv file
-            channel (discord.Channel): Channel to send the discord messages to
-
-        Outputs:
-            An embedded discord message that displays the user's tasks in column format
-        """
-
-        tasks_df = pd.read_csv(filepath)
-
-        embed = discord.Embed(
-            title = "Task List",
-            description = "List of your incomplete tasks",
-            colour = discord.Colour.from_rgb(3,105,55)
-        )
-
-        names = ""
-        task_ids = ""
-        time_spent = ""
-
-        for index, row in tasks_df.iterrows():
-            link = tasks_df.loc[index, 'link']
-            if (row['userid'] == interaction.user.id and row['status'] == "Incomplete"):
-                if url(str(link)):
-                    names += f"[{row['name']}]({link})\n"
-                else:
-                    names += f"{row['name']}\n"
-                task_ids += f"{row['number']}\n"
-                time_spent += f"{row['time spent']}\n"
-
-        embed.add_field(name="**Tasks**", value=names)
-        embed.add_field(name="**ID's**", value=task_ids)
-        embed.add_field(name="**Time Spent**", value=time_spent)
-
-        await channel.send(embed=embed)
-
-    async def complete(self, interaction:discord.Interaction, filepath:str, channel:discord.DMChannel):
-        """A function that marks a task as completed
-        Marks a specified task as completed in the status column of the csv
-
-        Args:
-            filepath (str): String representation of the path to the csv file
-            channel (discord.Channel): Channel to send the discord messages to
-
-        Outputs:
-            Sends a followup message either confirming the task was completed, or a message saying it could not be completed
-        """
-        
-        tasks_df = pd.read_csv(filepath)
-
-        await channel.send("Enter the ID of the task you wish to mark as complete")
-        task_id = await self.bot.wait_for('message', check=lambda message: message.author == interaction.user)
-        try:
-            int(task_id.content)
-        except:
-            await channel.send("Not a valid ID")
-            return
-
-        for index, row in tasks_df.iterrows():
-            if (row['userid'] == interaction.user.id and row['number'] == int(task_id.content) and row['status'] == "Incomplete"):
-                tasks_df.loc[index, 'status'] = 'Complete'
-                tasks_df.to_csv(filepath, index=False)
-
-                await channel.send(f'Task "{row["name"]}" with ID "{task_id.content}" has been completed.')
-                return
-
-        await channel.send("Nothing has been marked as complete as either the ID was not found, wasn't your task, or was already completed")
-
-    @app_commands.command(description="Add, list, or mark your tasks as complete")
-    async def task(self, interaction:discord.Interaction, option:str):
-        """Create and manage tasks
-        A function designed to allow the user to track small tasks
-        to increase productivity. Gives the user the option to create a new task,
-        list all incomplete tasks, or mark a specific task as complete.
-
-        Args:
-            option (str): Autocomplete parameter to allow the user to choose between creating, listing, or completing a task
-        
-        """
-        await interaction.response.send_message("Check your DM's", ephemeral=True)
-
-        csv_filepath = f'assets/tasks.csv'
-        if not (os.path.exists(csv_filepath)):
-            file = open(csv_filepath, "w")
-            file.write("userid,name,number,link,status,time spent\n")
-            file.close()
-
-        channel = await interaction.user.create_dm()
-
-        if (option == "Add"):
-            await self.add_task(interaction, csv_filepath, channel)
-        elif (option == "List"):
-            await self.list_tasks(interaction, csv_filepath, channel)
-        elif (option == "Mark Completed"):
-            await self.complete(interaction, csv_filepath, channel)
-
-    # Autocomplete functionality for the parameter "cog_name" in the load, reload, and unload commands
-    @task.autocomplete("option")
-    async def task_auto(self, interaction:discord.Interaction, current:str) -> List[app_commands.Choice[str]]:
-        data = []
-        choices = ["Add", "List", "Mark Completed"] 
-        # For every choice if the typed in value is in the choice add it to the possible options
-        for choice in choices:
-            if current.lower() in choice.lower():
-                data.append(app_commands.Choice(name=choice, value=choice))
-        return data
+            # This will eventually have some database interaction
+            await interaction.response.send_message("You have checked in! (not really)")

--- a/Cogs/Checkin.py
+++ b/Cogs/Checkin.py
@@ -36,3 +36,4 @@ class Checkin(commands.Cog):
         channel = await interaction.user.create_dm()
 
         await channel.send(view=view)
+        await interaction.response.send_message("A DM has been sent to you", ephemeral=True)

--- a/Cogs/Checkin.py
+++ b/Cogs/Checkin.py
@@ -39,7 +39,7 @@ class Checkin(commands.Cog):
         This will eventually have some database interaction
 
         Outputs:
-            A palceholder message to confirm a DM was sent to the user
+            A placeholder message to confirm a DM was sent to the user
         """
 
         discordID = interaction.user.id # for later use

--- a/Cogs/Checkin.py
+++ b/Cogs/Checkin.py
@@ -22,3 +22,17 @@ class Checkin(commands.Cog):
 
             # This will eventually have some database interaction
             await interaction.response.send_message("You have checked in! (not really)")
+
+    @app_commands.command(name="checkin-register", description="Register for checkin/timesheets!")
+    async def checkin_register(self, interaction:discord.Interaction):
+        """Allows a user to register for a check-in
+        This will eventually have some database interaction
+        """
+
+        discordID = interaction.user.id # for later use
+        discordUser = interaction.user.name # for later use
+
+        view = self.CheckinView()
+        channel = await interaction.user.create_dm()
+
+        await channel.send(view=view)


### PR DESCRIPTION
# Description

*Note: Everything previously in the Checkin cog was removed prior to implementation*

Added a `/checkin_register` command that DM's a user the 'Checkin View'. Currently the Checkin view is just a single button that says "Checkin" with a placeholder message sent after its pressed. It will eventually change the view to #308 after it is pressed, and a timesheet will be created in the database.

## Issues

Closes #307 and #311 

## Type of change

Select one or more of the following:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (describe below)

# How Has This Been Tested?

- [ ] Run `/checkin_register` in the CSE-Testing-Server
- [ ] Verify you received a dm from your bot
- [ ] Click the "Checkin" button on the screen
- [ ] A placeholder message should be sent on button-click

# Checklist:

- [x] All local commits have been pushed to remote
- [x] All changes on the base branch have been merged into this branch, either by rebase or merge
- [x] My code is [PEP-8](https://pep8.org/) compliant (excluding maximum line length, keep that to 100ish characters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [Google Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for all new functions/methods
- [x] I have made corresponding changes to the documentation
