### PR TITLE
Checked-in view

### DIFF
--- a/Cogs/Checkin.py
+++ b/Cogs/Checkin.py
@@ -51,6 +51,8 @@ class Checkin(commands.Cog):
         view.add_item(check_out_button)
         view.add_item(pomo_button)
 
+        return view
+
     @app_commands.command(name="checkin-register", description="Register for checkin/timesheets!")
     async def checkin_register(self, interaction:discord.Interaction):
         """Allows a user to register for a check-in

--- a/Cogs/Checkin.py
+++ b/Cogs/Checkin.py
@@ -42,7 +42,7 @@ class Checkin(commands.Cog):
             # This will eventually have some database interaction
             await interaction.response.send_message("You have checked in! (not really)")
 
-    async def checkedInView():
+    def checkedInView():
         """Function that returns the checked-in view
         The Checked-in View will contain a button to allow a user to check-out, as well as a button
         for a user to start a pomodoro

--- a/Cogs/Checkin.py
+++ b/Cogs/Checkin.py
@@ -42,38 +42,14 @@ class Checkin(commands.Cog):
             # This will eventually have some database interaction
             await interaction.response.send_message("You have checked in! (not really)")
 
-    class CheckedinView(View):
-        @discord.ui.button(label="Check-out", style=discord.ButtonStyle.red)
-        async def checkout(self, interaction:discord.Interaction, button:discord.ui.Button):
-            """A button that will update the user's timesheet in the SQLite database
+    async def checkedInView():
+        view = View()
 
-            This will eventually have some database interaction
+        check_out_button = discord.ui.Button(label="Check-out", style=discord.ButtonStyle.red, custom_id="checkoutbutton")
+        pomo_button = discord.ui.Button(label="Pomodoro", style=discord.ButtonStyle.blurple, custom_id="pomobutton")
 
-            Args:
-                button (discord.ui.Button): the button that will be clicked to check out
-
-            Outputs:
-                A View with a button that will update the user's timesheet in the SQLite database
-            """
-
-            # This will eventually have some database interaction
-            await interaction.response.send_message("You have checked out! (not really)")
-
-        @discord.ui.button(label="Pomodoro", style=discord.ButtonStyle.blurple)
-        async def pomodoro(self, interaction:discord.Interaction, button:discord.ui.Button):
-            """A button that will update the user's timesheet in the SQLite database
-
-            This will eventually have some database interaction
-
-            Args:
-                button (discord.ui.Button): the button that will be clicked to start a pomodoro
-
-            Outputs:
-                A View with a button that will update the user's timesheet in the SQLite database
-            """
-
-            # This will eventually have some database interaction
-            await interaction.response.send_message("You have started a pomodoro! (not really)")
+        view.add_item(check_out_button)
+        view.add_item(pomo_button)
 
     @app_commands.command(name="checkin-register", description="Register for checkin/timesheets!")
     async def checkin_register(self, interaction:discord.Interaction):

--- a/Cogs/Checkin.py
+++ b/Cogs/Checkin.py
@@ -42,6 +42,39 @@ class Checkin(commands.Cog):
             # This will eventually have some database interaction
             await interaction.response.send_message("You have checked in! (not really)")
 
+    class CheckedinView(View):
+        @discord.ui.button(label="Check-out", style=discord.ButtonStyle.red)
+        async def checkout(self, interaction:discord.Interaction, button:discord.ui.Button):
+            """A button that will update the user's timesheet in the SQLite database
+
+            This will eventually have some database interaction
+
+            Args:
+                button (discord.ui.Button): the button that will be clicked to check out
+
+            Outputs:
+                A View with a button that will update the user's timesheet in the SQLite database
+            """
+
+            # This will eventually have some database interaction
+            await interaction.response.send_message("You have checked out! (not really)")
+
+        @discord.ui.button(label="Pomodoro", style=discord.ButtonStyle.blurple)
+        async def pomodoro(self, interaction:discord.Interaction, button:discord.ui.Button):
+            """A button that will update the user's timesheet in the SQLite database
+
+            This will eventually have some database interaction
+
+            Args:
+                button (discord.ui.Button): the button that will be clicked to start a pomodoro
+
+            Outputs:
+                A View with a button that will update the user's timesheet in the SQLite database
+            """
+
+            # This will eventually have some database interaction
+            await interaction.response.send_message("You have started a pomodoro! (not really)")
+
     @app_commands.command(name="checkin-register", description="Register for checkin/timesheets!")
     async def checkin_register(self, interaction:discord.Interaction):
         """Allows a user to register for a check-in

--- a/Cogs/Checkin.py
+++ b/Cogs/Checkin.py
@@ -33,7 +33,7 @@ class Checkin(commands.Cog):
             This will eventually have some database interaction
 
             Args:
-                button (discord.ui.Button): the channels to which the announcement is sent
+                button (discord.ui.Button): the button that will be clicked to check in
 
             Outputs:
                 A View with a button that will create a timesheet for the user in the SQLite database

--- a/Cogs/Checkin.py
+++ b/Cogs/Checkin.py
@@ -43,6 +43,14 @@ class Checkin(commands.Cog):
             await interaction.response.send_message("You have checked in! (not really)")
 
     async def checkedInView():
+        """Function that returns the checked-in view
+        The Checked-in View will contain a button to allow a user to check-out, as well as a button
+        for a user to start a pomodoro
+
+        Outputs:
+            view (discord.ui.View) - The view containing the checkout and pomo buttons
+        """
+
         view = View()
 
         check_out_button = discord.ui.Button(label="Check-out", style=discord.ButtonStyle.red, custom_id="checkoutbutton")


### PR DESCRIPTION
# Description

Added a function that creates and returns a view. This "Checked-in" view contains 2 buttons: "Check-out" and "Pomodoro", which will check-out the user and allow them to start a pomodoro respectively. More integration will be required for the database but the discord-side is more or less done.

I also used a custom_id inside the buttons which should prevent future interactions from dropping.

## Issues

Closes #308 

## Type of change

Select one or more of the following:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (describe below)

# How Has This Been Tested?

Modified the `/checkin_register` command to send the new view that is returned from the `checkedInView` function, and verified the correct view was sent with the 2 new buttons.

# Checklist:

- [x] All local commits have been pushed to remote
- [x] All changes on the base branch have been merged into this branch, either by rebase or merge
- [x] My code is [PEP-8](https://pep8.org/) compliant (excluding maximum line length, keep that to 100ish characters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [Google Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for all new functions/methods
- [x] I have made corresponding changes to the documentation
