### PR TITLE
Converted custom_ids to follow standard convention

### DIFF
--- a/Cogs/Checkin.py
+++ b/Cogs/Checkin.py
@@ -35,8 +35,8 @@ class Checkin(commands.Cog):
 
 
         view = View()
-        check_in_button = discord.ui.Button(label="Check-in", style=discord.ButtonStyle.green, custom_id="checkinbutton")
-        view.add_item(check_in_button)
+        checkin_button = discord.ui.Button(label="Check-in", style=discord.ButtonStyle.green, custom_id="checkin_checkin_btn")
+        view.add_item(checkin_button)
 
         return view
 
@@ -51,10 +51,10 @@ class Checkin(commands.Cog):
 
         view = View()
 
-        check_out_button = discord.ui.Button(label="Check-out", style=discord.ButtonStyle.red, custom_id="checkoutbutton")
-        pomo_button = discord.ui.Button(label="Pomodoro", style=discord.ButtonStyle.blurple, custom_id="pomobutton")
+        checkout_button = discord.ui.Button(label="Check-out", style=discord.ButtonStyle.red, custom_id="checkedin_checkout_btn")
+        pomo_button = discord.ui.Button(label="Pomodoro", style=discord.ButtonStyle.blurple, custom_id="checkedin_pomo_btn")
 
-        view.add_item(check_out_button)
+        view.add_item(checkout_button)
         view.add_item(pomo_button)
 
         return view
@@ -69,9 +69,9 @@ class Checkin(commands.Cog):
         
         view = View()
 
-        done_button = discord.ui.Button(label="Done", style=discord.ButtonStyle.green, custom_id="pomo_done")
-        blocked_button = discord.ui.Button(label="Help/Blocked", style=discord.ButtonStyle.red, custom_id="pomo_blocked")
-        not_done_button = discord.ui.Button(label="Not Done", style=discord.ButtonStyle.secondary, custom_id="pomo_not_done")
+        done_button = discord.ui.Button(label="Done", style=discord.ButtonStyle.green, custom_id="pomo_done_btn")
+        blocked_button = discord.ui.Button(label="Help/Blocked", style=discord.ButtonStyle.red, custom_id="pomo_blocked_btn")
+        not_done_button = discord.ui.Button(label="Not Done", style=discord.ButtonStyle.secondary, custom_id="pomo_not_done_btn")
 
         view.add_item(done_button)
         view.add_item(blocked_button)


### PR DESCRIPTION
# Description

Converted the names of custom_ids to follow a new standard for listeners. Each button follows the standard of showing what view it comes from, what the button does, and then appends "_btn" to the end to denote the interaction is for a button.

## Issues

Closes #335 

## Type of change

Select one or more of the following:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (describe below)

# How Has This Been Tested?

No integration with the views has been set yet, so the need to test for changes is negated. All proper views are sent and the buttons have just had their custom_ids changed

# Checklist:

- [x] All local commits have been pushed to remote
- [x] All changes on the base branch have been merged into this branch, either by rebase or merge
- [x] My code is [PEP-8](https://pep8.org/) compliant (excluding maximum line length, keep that to 100ish characters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [Google Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for all new functions/methods
- [x] I have made corresponding changes to the documentation
