### PR TITLE
gitignore CSV lockfiles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ venv/
 
 # Ignore Visual Studio Code settings directory
 .vscode
+
+# Ignore lockfiles
+.~lock.*.csv#


### PR DESCRIPTION
# Description

Previously, lockfiles were automatically ignored, so I fixed it by adding `~lock.*.csv#` in `.gitignore`.

## Issues

Closes #77 

## Type of change

Select one or more of the following:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (describe below)

# How Has This Been Tested?

This has not been tested and I'm not entirely sure how I would test it.

# Checklist:

- [x] All local commits have been pushed to remote
- [x] All changes on the base branch have been merged into this branch, either by rebase or merge
- [x] My code is [PEP-8](https://pep8.org/) compliant (excluding maximum line length, keep that to 100ish characters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [Google Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for all new functions/methods
- [x] I have made corresponding changes to the documentation
