### PR TITLE
Automatically Close Timesheets and Pomodoros

### DIFF
--- a/Cogs/Checkin.py
+++ b/Cogs/Checkin.py
@@ -310,7 +310,7 @@ class Checkin(commands.Cog):
             for timesheet in timesheets:
                 time = await get_time_epoch()
                 
-                if time >= (float(timesheet[2]) + (0 * 60 * 60)):
+                if time >= (float(timesheet[2]) + (8 * 60 * 60)):
                     user = self.bot.get_user(int(timesheet[1]))
 
                     if user is not None:

--- a/utils/db_utils.py
+++ b/utils/db_utils.py
@@ -400,6 +400,7 @@ def get_pomodoro_id(conn, discord_id: str):
                 return None
             elif (len(timesheet) != 1):
                 print("Error! No pomodoro open for user.")
+                return None
             else:
                 return timesheet[0][0]
         except sqlite3.Error as e:
@@ -456,7 +457,7 @@ def get_all_open_pomodoros(conn):
         try:
             c = conn.cursor()
 
-            pomodoro_query = """SELECT pomodoro.*, timesheet.discord_id FROM pomodoro INNER JOIN timesheet ON pomodoro.timesheet_id = timesheet.time_id WHERE pomodoro.time_finish IS NULL and pomodoro.time_delta IS NULL and pomodoro.status IS NULL AND (pomodoro.status IS 0 OR pomodoro.status IS NULL)"""
+            pomodoro_query = """SELECT pomodoro.*, timesheet.discord_id FROM pomodoro INNER JOIN timesheet ON pomodoro.timesheet_id = timesheet.time_id WHERE pomodoro.time_finish IS NULL and pomodoro.time_delta IS NULL and pomodoro.status IS NULL AND (pomodoro.status IS 0 OR pomodoro.status IS 1 OR pomodoro.status IS NULL)"""
             c.execute(pomodoro_query)
 
             pomodoros = c.fetchall()
@@ -465,6 +466,66 @@ def get_all_open_pomodoros(conn):
                 return None
             else:
                 return pomodoros
+        except sqlite3.Error as e:
+            print(e)
+            conn.rollback()
+            return None
+    else:
+        print("Error! Cannot create database connection")
+
+def get_all_open_timesheets(conn):
+    """
+    Return all open timesheets for comparison
+
+    Args:
+        conn: Connection object returned by the `create_connection` function
+    Outputs:
+        timesheets (list): a list of all open timesheets
+    """
+    if conn is not None:
+        try:
+            c = conn.cursor()
+
+            timesheet_query = """SELECT * FROM timesheet WHERE time_out IS NULL and total_time IS NULL"""
+            c.execute(timesheet_query)
+
+            timesheets = c.fetchall()
+
+            if (len(timesheets) < 1):
+                return None
+            else:
+                return timesheets
+        except sqlite3.Error as e:
+            print(e)
+            conn.rollback()
+            return None
+    else:
+        print("Error! Cannot create database connection")
+
+def close_all_pomodoros(conn, time_id: str, end_time: float):
+    """
+    Close all pomodoros for a provided time_id
+    
+    Args:
+        conn: Connection object returned by the `create_connection` function
+        time_id: Timesheet ID to close all pomodoros associated with
+        end_time: Time epoch of end time
+    """
+    if conn is not None:
+        try:
+            c = conn.cursor()
+
+            pomodoro_query = """SELECT * FROM pomodoro WHERE timesheet_id = ?"""
+            c.execute(pomodoro_query, (time_id,))
+
+            pomodoros = c.fetchall()
+
+            if (len(pomodoros) > 0):
+                for pomodoro in pomodoros:
+                    start_time = float(pomodoro[3])
+                    total_time = end_time - start_time
+
+                    update_pomodoro(conn, pomodoro[0], pomodoro[1], pomodoro[2], pomodoro[3], end_time, total_time, 2)
         except sqlite3.Error as e:
             print(e)
             conn.rollback()

--- a/utils/db_utils.py
+++ b/utils/db_utils.py
@@ -504,7 +504,7 @@ def get_all_open_timesheets(conn):
 
 def close_all_pomodoros(conn, time_id: str, end_time: float):
     """
-    Close all pomodoros for a provided time_id
+    Close all open pomodoros for a provided time_id
     
     Args:
         conn: Connection object returned by the `create_connection` function
@@ -515,7 +515,7 @@ def close_all_pomodoros(conn, time_id: str, end_time: float):
         try:
             c = conn.cursor()
 
-            pomodoro_query = """SELECT * FROM pomodoro WHERE timesheet_id = ?"""
+            pomodoro_query = """SELECT * FROM pomodoro WHERE timesheet_id = ? AND time_finish is NULL AND time_delta IS NULL"""
             c.execute(pomodoro_query, (time_id,))
 
             pomodoros = c.fetchall()


### PR DESCRIPTION
# Description

Create a task to automatically close timesheets and their associated pomodoros after eight hours. Additionally, I converted the checkin clear command to be a function called by the command to allow for proper state reset on automatic close.

## Issues

Closes #386 

## Type of change

Select one or more of the following:

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (describe below)

# How Has This Been Tested?

I created the new tasks and verified that they properly closed open timesheets and their associated open pomodoros. After this, I began testing edge cases, including when a timesheet was open but no pomodoros were open. I also verified state reset functionality works as expected.

# Checklist:

- [x] All local commits have been pushed to remote
- [x] All changes on the base branch have been merged into this branch, either by rebase or merge
- [x] My code is [PEP-8](https://pep8.org/) compliant (excluding maximum line length, keep that to 100ish characters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [Google Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for all new functions/methods
- [ ] I have made corresponding changes to the documentation
