### PR TITLE
Fixed TA Wave Bug

### DIFF
--- a/Cogs/Listeners.py
+++ b/Cogs/Listeners.py
@@ -35,11 +35,11 @@ class Listeners(commands.Cog):
             # Only react if its in the help room channel and if the user has the TA role
             if ctx.channel.name == 'cs-help-room' and ta_role in ctx.author.roles:
                 # Establishes a list of keywords to check for in the message
-                keywords = ['greetings', 'hi', 'hello', 'hey', 'howdy', 'yo', 'sup', 'office hours', 'help room', 'helproom', 'russ', 'joshi']
+                keywords = ['greetings', 'hi', 'hi!', 'hello', 'hello!', 'hey', 'howdy', 'yo', 'sup', 'office hours', 'help room', 'helproom', 'russ', 'joshi']
                 message = ctx.content
 
                 # Add the reaction if any keywords are found in the message
-                if any(keyword in message.lower() for keyword in keywords):
+                if any(keyword in message.lower().split() for keyword in keywords):
                     await ctx.add_reaction("👋")
 
 


### PR DESCRIPTION
# Description

Fixed the TA wave reaction being added to nearly every TA message as a result of a string check for "yo"

## Issues

Closes #410 

## Type of change

Select one or more of the following:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (describe below)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. List any edge cases you tested.
If you come up with any edge cases you didn't test while writing this PR, cancel the PR and test again.

- [x] Verified reactions still added to TA messages
- [x] Verified reactions not added to incorrect TA messages

# Checklist:

- [x] All local commits have been pushed to remote
- [x] All changes on the base branch have been merged into this branch, either by rebase or merge
- [x] My code is [PEP-8](https://pep8.org/) compliant (excluding maximum line length, keep that to 100ish characters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [Google Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for all new functions/methods
- [ ] I have made corresponding changes to the documentation
