### PR TITLE
Fix extract corgies

### DIFF
--- a/Cogs/StudentCommands.py
+++ b/Cogs/StudentCommands.py
@@ -57,7 +57,7 @@ class StudentCommands(commands.Cog):
             await log(self.bot, 'Corgis directory not found, extracting tar file')
             
             # Extract the tar file
-            extract_corgis(self.bot, interaction)
+            await extract_corgis(self.bot, interaction)
 
         # Get images from directory
         images = ['assets/corgis/' + path.name for path in Path('assets/corgis/').rglob('*.*')]


### PR DESCRIPTION
# Description

In corgme under `Extract the tar file` an `await` was added to make the program asynchronous. This issue was found when trying to make `Evangeline` @Saucy-tgossett's tester bot. This is dependent on the `Cogs/StudentCommands.py`

## Issues

Closes #425

## Type of change

Select one or more of the following:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (describe below)

# How Has This Been Tested?

This was tested by launching `Evangeline`

[Testing Screenshot](https://cdn.discordapp.com/attachments/1417945180031680513/1419776268538347691/Screenshot_2025-09-22_16-03-52.png?ex=68d2fd30&is=68d1abb0&hm=d333af4483b73b69ecfeb84eae2b9fbe4507a631636a9382be48c2d899dcd6db&)

To reproduce results, simply start the bot and run `/corgme` in `#bot-logs`

# Checklist:

- [x] All local commits have been pushed to remote
- [x] All changes on the base branch have been merged into this branch, either by rebase or merge
- [x] My code is [PEP-8](https://pep8.org/) compliant (excluding maximum line length, keep that to 100ish characters)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added [Google Docstrings](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html) for all new functions/methods
- [x] I have made corresponding changes to the documentation
