### PR TITLE
Clears over 9000

### DIFF
--- a/Cogs/AdminCommands.py
+++ b/Cogs/AdminCommands.py
@@ -91,7 +91,7 @@ class AdminCommands(commands.Cog):
 
     @app_commands.command(description="clears either 'all' or the specified number of messages from the channel")
     @app_commands.default_permissions(administrator=True)
-    async def clear(self, interaction:discord.Interaction, amount:str):
+    async def clear(self, ctx, interaction:discord.Interaction):
         """Clears a specific number of messages from a guild
         Take in user input for the number of messages they would like to get cleared. If the amount is 'all',
         clear a very large number of messages from the server. Otherwise, send message confirming how many
@@ -103,41 +103,53 @@ class AdminCommands(commands.Cog):
         Outputs:
             States the amount of messages being cleared or, if invalid input, help on how to use the command
         """
-
-        await interaction.response.defer(ephemeral=True)
-        if amount == 'all':
-            if not await confirmation(self.bot, interaction):
-                await interaction.followup.send("Command not confirmed")
-                return
-            await interaction.channel.send('Clearing all messages from this channel')
-            await log(self.bot, f'{interaction.user} cleared {amount} messages from #{interaction.channel}')
-            amount = 999999999999999999999999999999999999999999
-
+        
+        interaction.channel = discord.utils.get(interaction.guild.text_channels, name=interaction.channel)
+        if interaction.channel is not None:
+            await interaction.channel.clone(reason="Has been nuked")
+            await interaction.channel.delete()
         else:
-            try:
-                amount = int(amount)
-            except ValueError:
-                await interaction.channel.send("The `amount` parameter can only take either `all` or a number.")
-                await log(self.bot, f'{interaction.user} attempted to clear messages from #{interaction.channel}, but it failed because a valid "amount" was not passed')
-                await interaction.followup.send("`amount` parameter is invalid")
-                return
+            await ctx.send(f'No channel named **{interaction.channel}** was found')
 
-            if amount < 10:
-                await interaction.channel.send(f'Clearing {amount} messages from this channel')
-                await log(self.bot, f'{interaction.user} cleared {amount} messages from #{interaction.channel}')
-                sleep(1)
-                await interaction.channel.purge(limit=int(float(amount)) + 1)
-                await interaction.followup.send(f'Cleared {amount} messages from this channel')
-                return
-            elif amount >= 10 and not await confirmation(self.bot, interaction):
-                await interaction.followup.send("Command not confirmed")
-                return
-            await interaction.channel.send(f'Clearing {amount} messages from this channel')
-            await log(self.bot, f'{interaction.user} cleared {amount} messages from #{interaction.channel}')
+        # await interaction.response.defer(ephemeral=True)
+        # if amount == 'all':
+        #     if not await confirmation(self.bot, interaction):
+        #         await interaction.followup.send("Command not confirmed")
+        #         return
+        #     await interaction.channel.clone(reason="Has been nuked")
+        #     await interaction.channel.delete()
+        #     await interaction.channel.send('Clearing all messages from this channel')
+        #     #await log(self.bot, f'{interaction.user} cleared {amount} messages from #{interaction.channel}')
+        #     #amount = 999999999999999999999999999999999999999999
+        
+        # else:
+        #     await ctx.send(f'No channel named **{interaction.channel}** was found')
 
-        sleep(1)
-        await interaction.channel.purge(limit=int(float(amount)) + 4)
-        await interaction.followup.send(f'Cleared {amount} messages from this channel')
+        # else:
+        #     try:
+        #         amount = int(amount)
+        #     except ValueError:
+        #         await interaction.channel.send("The `amount` parameter can only take either `all` or a number.")
+        #         await log(self.bot, f'{interaction.user} attempted to clear messages from #{interaction.channel}, but it failed because a valid "amount" was not passed')
+        #         await interaction.followup.send("`amount` parameter is invalid")
+        #         return
+
+        #     if amount < 10:
+        #         await interaction.channel.send(f'Clearing {amount} messages from this channel')
+        #         await log(self.bot, f'{interaction.user} cleared {amount} messages from #{interaction.channel}')
+        #         sleep(1)
+        #         await interaction.channel.purge(limit=int(float(amount)) + 1)
+        #         await interaction.followup.send(f'Cleared {amount} messages from this channel')
+        #         return
+        #     elif amount >= 10 and not await confirmation(self.bot, interaction):
+        #         await interaction.followup.send("Command not confirmed")
+        #         return
+        #     await interaction.channel.send(f'Clearing {amount} messages from this channel')
+        #     await log(self.bot, f'{interaction.user} cleared {amount} messages from #{interaction.channel}')
+
+        # sleep(1)
+        # await interaction.channel.purge(limit=int(float(amount)) + 4)
+        # await interaction.followup.send(f'Cleared {amount} messages from this channel')
 
 
     @app_commands.command(description="removes a specified role from each member of a guild.")

--- a/Cogs/AdminCommands.py
+++ b/Cogs/AdminCommands.py
@@ -109,13 +109,19 @@ class AdminCommands(commands.Cog):
                 await interaction.followup.send("Command not confirmed")
                 return
             await interaction.channel.send(f'Clearing all messages from this channel')
-
+            
+            # Grabs orignal channel position
+            original_position = interaction.channel.position
+            
             # Copies channel and deletes all messages
             new_channel = await interaction.channel.clone(reason="Has been nuked")
             await interaction.channel.delete(reason="Nuked by admin command")
             await log(self.bot, f'{interaction.user} cleared {amount} messages from #{interaction.channel}')
             
-            # @'s user who ran /clear command to the new channel created 
+            # Puts channel back in orignal position
+            await new_channel.edit(position=original_position)
+            
+            # @'s user who ran the /clear command to the new channel created 
             await new_channel.send(f'Cleared channel is ready: {interaction.user.mention}!')
             
         else:

--- a/Cogs/AdminCommands.py
+++ b/Cogs/AdminCommands.py
@@ -111,11 +111,13 @@ class AdminCommands(commands.Cog):
             await interaction.channel.send(f'Clearing all messages from this channel')
 
             # Copies channel and deletes all messages
-            await interaction.channel.clone(reason="Has been nuked")
+            new_channel = await interaction.channel.clone(reason="Has been nuked")
             await interaction.channel.delete(reason="Nuked by admin command")
             await log(self.bot, f'{interaction.user} cleared {amount} messages from #{interaction.channel}')
-            amount = 'all'
-
+            
+            # @'s user who ran /clear command to the new channel created 
+            await new_channel.send(f'Cleared channel is ready: {interaction.user.mention}!')
+            
         else:
             try:
                 amount = int(amount)

--- a/Cogs/AdminCommands.py
+++ b/Cogs/AdminCommands.py
@@ -88,68 +88,116 @@ class AdminCommands(commands.Cog):
         # logs appropriately
         await log(self.bot, f"{interaction.user} made an announcement from #{interaction.channel} to {', '.join(channel_names)}")
 
+        @app_commands.command(description="clears either 'all' or the specified number of messages from the channel")
+        @app_commands.default_permissions(administrator=True)
+        async def clear(self, ctx,  interaction:discord.Interaction, amount:str):
+            """Clears a specific number of messages from a guild
+            Take in user input for the number of messages they would like to get cleared. If the amount is 'all',
+            clear a very large number of messages from the server. Otherwise, send message confirming how many
+            messages are being cleared and log it. Purge the appropriate number of messages from the channel.
 
-    @app_commands.command(description="clears either 'all' or the specified number of messages from the channel")
-    @app_commands.default_permissions(administrator=True)
-    async def clear(self, ctx, interaction:discord.Interaction):
-        """Clears a specific number of messages from a guild
-        Take in user input for the number of messages they would like to get cleared. If the amount is 'all',
-        clear a very large number of messages from the server. Otherwise, send message confirming how many
-        messages are being cleared and log it. Purge the appropriate number of messages from the channel.
+            Args:
+                amount (str): Number of messages to be removed
 
-        Args:
-            amount (str): Number of messages to be removed
+            Outputs:
+                States the amount of messages being cleared or, if invalid input, help on how to use the command
+            """
 
-        Outputs:
-            States the amount of messages being cleared or, if invalid input, help on how to use the command
-        """
-        
-        interaction.channel = discord.utils.get(interaction.guild.text_channels, name=interaction.channel)
-        if interaction.channel is not None:
-            await interaction.channel.clone(reason="Has been nuked")
-            await interaction.channel.delete()
+        await interaction.response.defer(ephemeral=True)
+        if amount == 'all':
+            if not await confirmation(self.bot, interaction):
+                await interaction.followup.send("Command not confirmed")
+                return
+            await interaction.channel.send(f'Clearing all messages from this channel')
+            # needs to make a copy of the channel
+            # needs to delete the og channel
+            interaction.channel = discord.utils.get(interaction.guild.channel, name=interaction.channel)
+            if interaction.channel is not None:
+                await interaction.channel.clone(reason="Has been nuked")
+                await interaction.channel.purge()
+            await log(self.bot, f'{interaction.user} cleared {amount} messages from #{interaction.channel}')
+            amount = interaction.channel.purge()
+
         else:
-            await ctx.send(f'No channel named **{interaction.channel}** was found')
+            try:
+                amount = int(amount)
+            except ValueError:
+                await interaction.channel.send("The `amount` parameter can only take either `all` or a number.")
+                await log(self.bot, f'{interaction.user} attempted to clear messages from #{interaction.channel}, but it failed because a valid "amount" was not passed')
+                await interaction.followup.send("`amount` parameter is invalid")
+                return
 
-        # await interaction.response.defer(ephemeral=True)
-        # if amount == 'all':
-        #     if not await confirmation(self.bot, interaction):
-        #         await interaction.followup.send("Command not confirmed")
-        #         return
-        #     await interaction.channel.clone(reason="Has been nuked")
-        #     await interaction.channel.delete()
-        #     await interaction.channel.send('Clearing all messages from this channel')
-        #     #await log(self.bot, f'{interaction.user} cleared {amount} messages from #{interaction.channel}')
-        #     #amount = 999999999999999999999999999999999999999999
+            if amount < 10:
+                await interaction.channel.send(f'Clearing {amount} messages from this channel')
+                await log(self.bot, f'{interaction.user} cleared {amount} messages from #{interaction.channel}')
+                sleep(1)
+                await interaction.channel.purge(limit=int(float(amount)) + 1)
+                await interaction.followup.send(f'Cleared {amount} messages from this channel')
+                return
+            elif amount >= 10 and not await confirmation(self.bot, interaction):
+                await interaction.followup.send("Command not confirmed")
+                return
+            await interaction.channel.send(f'Clearing {amount} messages from this channel')
+            await log(self.bot, f'{interaction.user} cleared {amount} messages from #{interaction.channel}')
+
+        sleep(1)
+        await interaction.channel.purge(limit=int(float(amount)) + 4)
+        await interaction.followup.send(f'Cleared {amount} messages from this channel')
         
-        # else:
-        #     await ctx.send(f'No channel named **{interaction.channel}** was found')
+    # @app_commands.command(description="clears all messages from the channel")
+    # @app_commands.default_permissions(administrator=True)
+    # async def clear(self, ctx, interaction:discord.Interaction, input:str):
+    #     """Clears all messages from a guild
+    #     Purge all messages from the channel, send message confirming that all messages 
+    #     have been deleted and log it.
+    #     Take in user input to make sure they  would like the channel to get cleared.
 
-        # else:
-        #     try:
-        #         amount = int(amount)
-        #     except ValueError:
-        #         await interaction.channel.send("The `amount` parameter can only take either `all` or a number.")
-        #         await log(self.bot, f'{interaction.user} attempted to clear messages from #{interaction.channel}, but it failed because a valid "amount" was not passed')
-        #         await interaction.followup.send("`amount` parameter is invalid")
-        #         return
+    #     Args:
+    #         input (str): Confirmation to nuke all messages in the channel 
 
-        #     if amount < 10:
-        #         await interaction.channel.send(f'Clearing {amount} messages from this channel')
-        #         await log(self.bot, f'{interaction.user} cleared {amount} messages from #{interaction.channel}')
-        #         sleep(1)
-        #         await interaction.channel.purge(limit=int(float(amount)) + 1)
-        #         await interaction.followup.send(f'Cleared {amount} messages from this channel')
-        #         return
-        #     elif amount >= 10 and not await confirmation(self.bot, interaction):
-        #         await interaction.followup.send("Command not confirmed")
-        #         return
-        #     await interaction.channel.send(f'Clearing {amount} messages from this channel')
-        #     await log(self.bot, f'{interaction.user} cleared {amount} messages from #{interaction.channel}')
+    #     Outputs:
+    #         States that messages have been cleared or, if invalid input, help on how to use the command
+    #     """
+        
+    #     await interaction.response.defer(ephemeral=True)
+        
+    #     if input.lower() == 'yes' or 'y':
+    #         if not await confirmation(self.bot, interaction):
+    #             await interaction.followup.send("Clearing process stopped")
+    #             return
+    #         await interaction.channel.send(f'Clearing all messages from this channel')
+    #         #await log(self.bot, f'{interaction.user} cleared {amount} messages from #{interaction.channel}')
+    #     else:
+    #         try:
+    #             input = str(input)
+    #         except ValueError:
+    #             await interaction.channel.send("The `input` parameter can only take either '(y)es' or '(n)o'.")
+    #             await log(self.bot, f'{interaction.user} attempted to clear messages from #{interaction.channel}, but it failed because a valid "input" was not passed')
+    #             await interaction.followup.send("`input` parameter is invalid")
+    #             return
 
-        # sleep(1)
-        # await interaction.channel.purge(limit=int(float(amount)) + 4)
-        # await interaction.followup.send(f'Cleared {amount} messages from this channel')
+    #         if input.lower == 'yes' or 'y':
+    #             # needs to make a copy of the channel
+    #             # needs to delete the og channel
+    #             interaction.channel = discord.utils.get(interaction.guild.channel, name=interaction.channel)
+    #             if interaction.channel is not None:
+    #                 await interaction.channel.clone(reason="Has been nuked")
+    #                 await interaction.channel.purge()
+    #             await interaction.channel.send(f'Clearing all messages from this channel')
+    #             await log(self.bot, f'{interaction.user} cleared all messages from #{interaction.channel}')
+    #             sleep(1)
+    #             # await interaction.channel.purge(limit=int(float(input)) + 1)
+    #             # await interaction.followup.send(f'Cleared all messages from this channel')
+    #             return
+    #         elif input.lower == 'no' or 'n' and not await confirmation(self.bot, interaction):
+    #             await interaction.followup.send("Clearing process stopped")
+    #             return
+    #         await interaction.channel.send(f'Clearing all messages from this channel')
+    #         await log(self.bot, f'{interaction.user} cleared all messages from #{interaction.channel}')
+
+    #     sleep(1)
+    #     await interaction.channel.purge()
+    #     await interaction.followup.send(f'Cleared all messages from this channel')
 
 
     @app_commands.command(description="removes a specified role from each member of a guild.")

--- a/Cogs/AdminCommands.py
+++ b/Cogs/AdminCommands.py
@@ -88,20 +88,20 @@ class AdminCommands(commands.Cog):
         # logs appropriately
         await log(self.bot, f"{interaction.user} made an announcement from #{interaction.channel} to {', '.join(channel_names)}")
 
-        @app_commands.command(description="clears either 'all' or the specified number of messages from the channel")
-        @app_commands.default_permissions(administrator=True)
-        async def clear(self, ctx,  interaction:discord.Interaction, amount:str):
-            """Clears a specific number of messages from a guild
-            Take in user input for the number of messages they would like to get cleared. If the amount is 'all',
-            clear a very large number of messages from the server. Otherwise, send message confirming how many
-            messages are being cleared and log it. Purge the appropriate number of messages from the channel.
+    @app_commands.command(description="clears either 'all' or the specified number of messages from the channel")
+    @app_commands.default_permissions(administrator=True)
+    async def clear(self, interaction:discord.Interaction, amount:str):
+        """Clears a specific number of messages from a guild
+        Take in user input for the number of messages they would like to get cleared. If the amount is 'all',
+        clear a very large number of messages from the server. Otherwise, send message confirming how many
+        messages are being cleared and log it. Purge the appropriate number of messages from the channel.
 
-            Args:
-                amount (str): Number of messages to be removed
+        Args:
+            amount (str): Number of messages to be removed
 
-            Outputs:
-                States the amount of messages being cleared or, if invalid input, help on how to use the command
-            """
+        Outputs:
+            States the amount of messages being cleared or, if invalid input, help on how to use the command
+        """
 
         await interaction.response.defer(ephemeral=True)
         if amount == 'all':
@@ -109,14 +109,12 @@ class AdminCommands(commands.Cog):
                 await interaction.followup.send("Command not confirmed")
                 return
             await interaction.channel.send(f'Clearing all messages from this channel')
-            # needs to make a copy of the channel
-            # needs to delete the og channel
-            interaction.channel = discord.utils.get(interaction.guild.channel, name=interaction.channel)
-            if interaction.channel is not None:
-                await interaction.channel.clone(reason="Has been nuked")
-                await interaction.channel.purge()
+
+            # Copies channel and deletes all messages
+            await interaction.channel.clone(reason="Has been nuked")
+            await interaction.channel.delete(reason="Nuked by admin command")
             await log(self.bot, f'{interaction.user} cleared {amount} messages from #{interaction.channel}')
-            amount = interaction.channel.purge()
+            amount = 'all'
 
         else:
             try:
@@ -137,68 +135,10 @@ class AdminCommands(commands.Cog):
             elif amount >= 10 and not await confirmation(self.bot, interaction):
                 await interaction.followup.send("Command not confirmed")
                 return
+
             await interaction.channel.send(f'Clearing {amount} messages from this channel')
+            await interaction.channel.purge(limit=int(float(amount)) + 4)
             await log(self.bot, f'{interaction.user} cleared {amount} messages from #{interaction.channel}')
-
-        sleep(1)
-        await interaction.channel.purge(limit=int(float(amount)) + 4)
-        await interaction.followup.send(f'Cleared {amount} messages from this channel')
-        
-    # @app_commands.command(description="clears all messages from the channel")
-    # @app_commands.default_permissions(administrator=True)
-    # async def clear(self, ctx, interaction:discord.Interaction, input:str):
-    #     """Clears all messages from a guild
-    #     Purge all messages from the channel, send message confirming that all messages 
-    #     have been deleted and log it.
-    #     Take in user input to make sure they  would like the channel to get cleared.
-
-    #     Args:
-    #         input (str): Confirmation to nuke all messages in the channel 
-
-    #     Outputs:
-    #         States that messages have been cleared or, if invalid input, help on how to use the command
-    #     """
-        
-    #     await interaction.response.defer(ephemeral=True)
-        
-    #     if input.lower() == 'yes' or 'y':
-    #         if not await confirmation(self.bot, interaction):
-    #             await interaction.followup.send("Clearing process stopped")
-    #             return
-    #         await interaction.channel.send(f'Clearing all messages from this channel')
-    #         #await log(self.bot, f'{interaction.user} cleared {amount} messages from #{interaction.channel}')
-    #     else:
-    #         try:
-    #             input = str(input)
-    #         except ValueError:
-    #             await interaction.channel.send("The `input` parameter can only take either '(y)es' or '(n)o'.")
-    #             await log(self.bot, f'{interaction.user} attempted to clear messages from #{interaction.channel}, but it failed because a valid "input" was not passed')
-    #             await interaction.followup.send("`input` parameter is invalid")
-    #             return
-
-    #         if input.lower == 'yes' or 'y':
-    #             # needs to make a copy of the channel
-    #             # needs to delete the og channel
-    #             interaction.channel = discord.utils.get(interaction.guild.channel, name=interaction.channel)
-    #             if interaction.channel is not None:
-    #                 await interaction.channel.clone(reason="Has been nuked")
-    #                 await interaction.channel.purge()
-    #             await interaction.channel.send(f'Clearing all messages from this channel')
-    #             await log(self.bot, f'{interaction.user} cleared all messages from #{interaction.channel}')
-    #             sleep(1)
-    #             # await interaction.channel.purge(limit=int(float(input)) + 1)
-    #             # await interaction.followup.send(f'Cleared all messages from this channel')
-    #             return
-    #         elif input.lower == 'no' or 'n' and not await confirmation(self.bot, interaction):
-    #             await interaction.followup.send("Clearing process stopped")
-    #             return
-    #         await interaction.channel.send(f'Clearing all messages from this channel')
-    #         await log(self.bot, f'{interaction.user} cleared all messages from #{interaction.channel}')
-
-    #     sleep(1)
-    #     await interaction.channel.purge()
-    #     await interaction.followup.send(f'Cleared all messages from this channel')
-
 
     @app_commands.command(description="removes a specified role from each member of a guild.")
     @app_commands.default_permissions(administrator=True)


### PR DESCRIPTION
# Description

Edited `/clear` so that when 'all' is inputted, it just copies the channel and deletes the old one instead of deleting messages one by one. Also made it so that when the new cleared channel is created, it @'s the user who made the initial `/clear` command within said new channel.

## Issues

Closes #432 

## Type of change

Select one or more of the following:

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Other (describe below)

# How Has This Been Tested?

## Ran `/clear` with a number (in this case 5)

### Before run - 

<img width="1513" height="1201" alt="Before-_clear" src="https://github.com/user-attachments/assets/a17df08e-7120-4bac-82a8-208b8506030a" />

### After run - 

<img width="1513" height="1198" alt="After-_clear" src="https://github.com/user-attachments/assets/ab5c34db-170c-4a24-b4b8-e9af1db50324" />

## Ran `/clear` 'all'

### Before run - 

<img width="1511" height="1194" alt="Before-_clear_all" src="https://github.com/user-attachments/assets/206ca254-844d-4dbc-bb4f-861daa30f32a" />


### After run - 

<img width="1508" height="1199" alt="After-_clear_all" src="https://github.com/user-attachments/assets/ff12c53a-3162-4aaf-b00e-79bdd1ee2c21" />
